### PR TITLE
fix: missing delimiters among tpl of cronjob, hook, worker and worker-hpa

### DIFF
--- a/charts/spartan/README.md
+++ b/charts/spartan/README.md
@@ -14,7 +14,7 @@ This chart bootstraps a deployment on a [Kubernetes](http://kubernetes.io) clust
 ## Get Repo Info
 
 ```bash
-helm repo add spartan https://spartan-stratos.github.io/helm-charts/
+helm repo add spartan https://spartan-stratos.github.io/helm-charts
 helm repo update
 ```
 

--- a/charts/spartan/templates/cronjob.yaml
+++ b/charts/spartan/templates/cronjob.yaml
@@ -1,3 +1,6 @@
-{{- range .Values.cronjobs }}
-  {{- include "spartan.cronjob" (dict "cronjob" . "Values" $.Values "Chart" $.Chart "Release" $.Release) }}
+{{- range $index, $cronjob := (.Values.cronjobs) }}
+  {{- include "spartan.cronjob" (dict "cronjob" $cronjob "Values" $.Values "Chart" $.Chart "Release" $.Release) }}
+  {{- if lt $index (sub (len $.Values.cronjobs) 1) }}
+---
+  {{- end }}
 {{- end }}

--- a/charts/spartan/templates/hook.yaml
+++ b/charts/spartan/templates/hook.yaml
@@ -1,5 +1,8 @@
-{{- range .Values.hooks }}
+{{- range $index, $hook := (.Values.hooks) }}
   {{ if .commands }}
-  {{- include "spartan.hook" (dict "hook" . "Values" $.Values "Chart" $.Chart "Release" $.Release) }}
+    {{- include "spartan.hook" (dict "hook" $hook "Values" $.Values "Chart" $.Chart "Release" $.Release) }}
+    {{- if lt $index (sub (len $.Values.hooks) 1) }}
+---
+    {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/spartan/templates/worker-hpa.yaml
+++ b/charts/spartan/templates/worker-hpa.yaml
@@ -1,7 +1,10 @@
-{{- range .Values.workers }}
-{{- if (dig "autoscaling" false .) }}
-{{- if .autoscaling.enabled }}
-  {{- include "spartan.workerHpa" (dict "worker" . "Values" $.Values "Chart" $.Chart "Release" $.Release) }}
-{{- end }}
-{{- end }}
+{{- range $index, $worker := (.Values.workers) }}
+  {{- if (dig "autoscaling" false $worker) }}
+    {{- if .autoscaling.enabled }}
+      {{- include "spartan.workerHpa" (dict "worker" $worker "Values" $.Values "Chart" $.Chart "Release" $.Release) }}
+      {{- if lt $index (sub (len $.Values.workers) 1) }}
+---
+      {{- end }}
+    {{- end }}
+  {{- end }}
 {{- end }}

--- a/charts/spartan/templates/worker.yaml
+++ b/charts/spartan/templates/worker.yaml
@@ -1,3 +1,6 @@
-{{- range .Values.workers }}
-  {{- include "spartan.worker" (dict "worker" . "Values" $.Values "Chart" $.Chart "Release" $.Release) }}
+{{- range $index, $worker := (.Values.workers) }}
+  {{- include "spartan.worker" (dict "worker" $worker "Values" $.Values "Chart" $.Chart "Release" $.Release) }}
+  {{- if lt $index (sub (len $.Values.workers) 1) }}
+---
+  {{- end }}
 {{- end }}


### PR DESCRIPTION
## Summary
<!--- Summary of changes --->
1. Add delimiters `---` to separate between resources when helm render the template files: including
- cronjob
- hook
- worker
- worker-hpa
2. Lint the chart URL in README.md

After this PR merged, will create 1 PR to update CHANGELOG.
Then, create 1 PR to fork the README.md to branch `/gh-pages`.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: --->

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which does not change existing behavior or add new functionality)
- [ ] Library update (non-breaking change that will update one or more libraries to newer versions)
- [ ] Domestic (documentation, non-breaking change that doesn't change code behavior, can skip testing)

## Test Plan:
<!--- How do you test your changes? (unit test, integration test, dev test) or skip_test if it's not applicable  --->
1. Add 1 more array object to `./test/values.yaml` for each targets.
2. Change dir to chart spartan `cd charts/spartan`
3. Run `helm template spartan . --debug -f "../../test/values.yaml" > template-file.yaml`
4. Validate delimiters

## Jira Issues:
<!--- Link to your YouTrack ticket --->
