### PR TITLE
feat: hook datadog-agent collect log

### DIFF
--- a/charts/spartan/CHANGELOG.md
+++ b/charts/spartan/CHANGELOG.md
@@ -2,11 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.2](https://github.com/spartan-stratos/helm-charts/releases/tag/spartan-0.1.1) (2024-12-27)
+
+### Features
+
+* Add `collectLog` field in hook to enable/disable collect the logs from datadog-agent [#5](https://github.com/spartan-stratos/helm-charts/pull/5)
+
 ## [0.1.1](https://github.com/spartan-stratos/helm-charts/releases/tag/spartan-0.1.1) (2024-11-20)
 
 ### Bug Fixes
 
-* Add missing delimiters among tpl of cronjob, hook, worker and worker-hpa [#4](https://github.com/spartan-stratos/helm-charts/pull/4) ([e87b57](https://github.com/spartan-stratos/helm-charts/commit/e87b575d37088319ab6c4e138f07562cdcdb439e))
+* Add missing delimiters among tpl of cronjob, hook, worker and worker-hpa [#4](https://github.com/spartan-stratos/helm-charts/pull/4)
 
 ## [0.1.0](https://github.com/spartan-stratos/helm-charts/releases/tag/spartan-0.1.0) (2024-11-11)
 

--- a/charts/spartan/CHANGELOG.md
+++ b/charts/spartan/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
-* Add `collectLog` field in hook to enable/disable collect the logs from datadog-agent [#5](https://github.com/spartan-stratos/helm-charts/pull/5)
+* Add `collectLog` field in hook to enable/disable collect the logs from datadog-agent [#9](https://github.com/spartan-stratos/helm-charts/pull/9)
 
 ## [0.1.1](https://github.com/spartan-stratos/helm-charts/releases/tag/spartan-0.1.1) (2024-11-20)
 

--- a/charts/spartan/values.yaml
+++ b/charts/spartan/values.yaml
@@ -295,6 +295,7 @@ hooks:
 #    extraEnvs:
 #    - name: SERVICE
 #      value: hook
+#    collectLog: false
 
 ## cronjobs specifies list of cronjobs
 cronjobs: []

--- a/test/values.yaml
+++ b/test/values.yaml
@@ -248,6 +248,24 @@ hooks:
     extraEnvs:
       - name: SERVICE
         value: hook
+    collectLog: false
+  - name: "datadog-agent"
+    hookTypes: "post-install,post-upgrade"
+    hookWeight: 0
+    shell: /bin/bash
+    commands:
+      - ls -la
+    resources: {}
+    customImage:
+      enabled: false
+      image: busybox
+    podAnnotations: {}
+    restartPolicy: Never
+    backoffLimit: 0
+    extraEnvs:
+      - name: SERVICE
+        value: hook
+    collectLog: false
 
 cronjobs:
   - name: "cleanup"


### PR DESCRIPTION
## Summary
Enable/Disable datadog-agent collect the logs in hooks to reduce the deployment time

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which does not change existing behavior or add new functionality)
- [ ] Library update (non-breaking change that will update one or more libraries to newer versions)
- [ ] Domestic (documentation, non-breaking change that doesn't change code behavior, can skip testing)

## Test Plan:
- Verify the outputs:
  + Enable datadog, have the datadog agent, and enable hook to collect logs
```
# Source: spartan/templates/hook.yaml
apiVersion: batch/v1
kind: Job
metadata:
  name: test-run-helm-check-hook-datadog-agent
  labels:
    helm.sh/chart: spartan-0.1.1
    app.kubernetes.io/name: run-helm-check
    app.kubernetes.io/instance: test
    app.kubernetes.io/version: "0.1.1"
    app.kubernetes.io/managed-by: Helm
    tier: "hook"
  annotations:
    "helm.sh/hook": "post-install,post-upgrade"
    "helm.sh/hook-weight": "0"
    "helm.sh/resource-policy": keep
spec:
  backoffLimit: 0
  template:
    metadata:
      annotations:
        test: hehe
      labels:
        app.kubernetes.io/name: run-helm-check-hook
        app.kubernetes.io/instance: test-hook
        tier: "hook"
    spec:
      serviceAccountName: test-run-helm-check
      securityContext:
        {}
      restartPolicy: Never
      shareProcessNamespace: true
      containers:
        - name: spartan
          securityContext:
            {}
          image: "nginx:latest"
          imagePullPolicy: IfNotPresent
          command:
            - /bin/bash
            - -c
            - |
              trap 'sleep 10 && pkill agent' EXIT
              set -o pipefail
              if [ ! `which curl` ]; then sleep 300; else while ! curl -Ns localhost:8126; do sleep 1 && echo "Waiting for datadog agent to start...."; done; fi
              ls -la
          resources:
            {}
          envFrom:
            - secretRef:
                name: test-run-helm-check-secret-as-env
            - secretRef:
                name: external-secret-env
            - configMapRef:
                name: test-run-helm-check-cm-as-env
            - configMapRef:
                name: external-config-map-env
          env:
            - name: DD_KUBERNETES_KUBELET_NODENAME
              valueFrom:
                fieldRef:
                  apiVersion: v1
                  fieldPath: spec.nodeName
            - name: DD_LOGS_ENABLED
              value: "true"
            - name: DD_LOGS_INJECTION
              value: "true"
            - name: DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL
              value: "true"
            - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
              value: "true"
            - name: DD_PROCESS_AGENT_ENABLED
              value: "true"
            - name: DD_CLUSTER_AGENT_ENABLED
              value: "true"
            - name: SERVICE
              value: hook
            - name: VERSION
              value: 1.0.0
          volumeMounts:
            - name: test-run-helm-check-secret-as-file
              readOnly: true
              mountPath: "/data/config"
            - name: external-secret-file
              readOnly: true
              mountPath: "/data/config"
            - name: test-run-helm-check-cm-as-file
              readOnly: true
              mountPath: "/data/config"
            - name: external-config-map-file
              readOnly: true
              mountPath: "/data/config"
            - name: sidecar-volume
              readOnly: false
              mountPath: /var/log/application/
              subPath: datadog-agent
                    
        - name: datadog-agent
          image: datadog/agent
          imagePullPolicy: "IfNotPresent"
          envFrom:
            - secretRef:
                name: test-run-helm-check-secret-as-env
            - secretRef:
                name: external-secret-env
            - configMapRef:
                name: test-run-helm-check-cm-as-env
            - configMapRef:
                name: external-config-map-env
          env:
            - name: DD_KUBERNETES_KUBELET_NODENAME
              valueFrom:
                fieldRef:
                  apiVersion: v1
                  fieldPath: spec.nodeName
            - name: DD_LOGS_ENABLED
              value: "true"
            - name: DD_LOGS_INJECTION
              value: "true"
            - name: DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL
              value: "true"
            - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
              value: "true"
            - name: DD_PROCESS_AGENT_ENABLED
              value: "true"
            - name: DD_CLUSTER_AGENT_ENABLED
              value: "true"
            - name: SERVICE
              value: sidecar
            - name: VERSION
              value: 1.0.0
          ports:
            - containerPort: 8125
              name: dogstatsdport
              protocol: UDP
            - containerPort: 8126
              name: traceport
              protocol: TCP
          volumeMounts:
            - name: test-run-helm-check-secret-as-file
              readOnly: true
              mountPath: "/data/config"
            - name: external-secret-file
              readOnly: true
              mountPath: "/data/config"
            - name: test-run-helm-check-cm-as-file
              readOnly: true
              mountPath: "/data/config"
            - name: external-config-map-file
              readOnly: true
              mountPath: "/data/config"
            - mountPath: "/var/log/application/"
              name: sidecar-volume
              subPath: "datadog-agent"
      volumes:
        - name: test-run-helm-check-secret-as-file
          secret:
            secretName: test-run-helm-check-secret-as-file
        - name: external-secret-file
          secret:
            secretName: external-secret-file
        - name: test-run-helm-check-cm-as-file
          configMap:
            name: test-run-helm-check-cm-as-file
        - name: external-config-map-file
          configMap:
            name: external-config-map-file
        - name: sidecar-volume
          emptyDir: {}

```

  + Have no datadog agent and disable the collection
  
```
---
# Source: spartan/templates/hook.yaml
apiVersion: batch/v1
kind: Job
metadata:
  name: test-run-helm-check-hook-datadog-agent
  labels:
    helm.sh/chart: spartan-0.1.1
    app.kubernetes.io/name: run-helm-check
    app.kubernetes.io/instance: test
    app.kubernetes.io/version: "0.1.1"
    app.kubernetes.io/managed-by: Helm
    tier: "hook"
  annotations:
    "helm.sh/hook": "post-install,post-upgrade"
    "helm.sh/hook-weight": "0"
    "helm.sh/resource-policy": keep
spec:
  backoffLimit: 0
  template:
    metadata:
      annotations:
        test: hehe
      labels:
        app.kubernetes.io/name: run-helm-check-hook
        app.kubernetes.io/instance: test-hook
        tier: "hook"
    spec:
      serviceAccountName: test-run-helm-check
      securityContext:
        {}
      restartPolicy: Never
      containers:
        - name: spartan
          securityContext:
            {}
          image: "nginx:latest"
          imagePullPolicy: IfNotPresent
          command:
            - /bin/bash
            - -c
            - |
              ls -la
          resources:
            {}
          envFrom:
            - secretRef:
                name: test-run-helm-check-secret-as-env
            - secretRef:
                name: external-secret-env
            - configMapRef:
                name: test-run-helm-check-cm-as-env
            - configMapRef:
                name: external-config-map-env
          env:
            - name: SERVICE
              value: hook
            - name: VERSION
              value: 1.0.0
          volumeMounts:
            - name: test-run-helm-check-secret-as-file
              readOnly: true
              mountPath: "/data/config"
            - name: external-secret-file
              readOnly: true
              mountPath: "/data/config"
            - name: test-run-helm-check-cm-as-file
              readOnly: true
              mountPath: "/data/config"
            - name: external-config-map-file
              readOnly: true
              mountPath: "/data/config"
            - name: sidecar-volume
              readOnly: false
              mountPath: /var/log/application/
              subPath: datadog-agent
      volumes:
        - name: test-run-helm-check-secret-as-file
          secret:
            secretName: test-run-helm-check-secret-as-file
        - name: external-secret-file
          secret:
            secretName: external-secret-file
        - name: test-run-helm-check-cm-as-file
          configMap:
            name: test-run-helm-check-cm-as-file
        - name: external-config-map-file
          configMap:
            name: external-config-map-file
        - name: sidecar-volume
          emptyDir: {}

```
## Jira Issues:
N/A