### PR TITLE
feat: worker keda

### DIFF
--- a/charts/spartan/templates/_worker-hpa.tpl
+++ b/charts/spartan/templates/_worker-hpa.tpl
@@ -30,4 +30,5 @@ spec:
           type: Utilization
           averageUtilization: {{ .worker.autoscaling.targetMemoryUtilizationPercentage }}
     {{- end }}
+---
 {{ end }}

--- a/charts/spartan/templates/_worker-keda.tpl
+++ b/charts/spartan/templates/_worker-keda.tpl
@@ -1,0 +1,38 @@
+{{ define "spartan.workerKeda" }}
+{{- $fullName := .worker.name -}}
+{{- range .worker.keda.authentication }}
+apiVersion: keda.sh/v1alpha1
+kind: TriggerAuthentication
+metadata:
+  name: {{ include "spartan.fullname" $ }}-worker-{{ $fullName }}-{{ .name }}
+spec:
+  podIdentity:
+    provider: {{ .podIdentity.provider }}
+    identityOwner: {{ .podIdentity.identityOwner | default "workload" }}
+---
+{{- end }}
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: {{ include "spartan.fullname" $ }}-worker-{{ $fullName }}
+spec:
+  minReplicaCount: {{ .worker.keda.minReplicas}}
+  maxReplicaCount: {{ .worker.keda.maxReplicas}}
+  pollingInterval: {{ .worker.keda.pollingInterval}}
+  scaleTargetRef:
+    name: {{ include "spartan.fullname" $ }}-worker-{{ .worker.name}}
+  triggers:
+    {{- range .worker.keda.triggers }}
+    - type: {{ .type }}
+      {{- if .metricType }}
+      metricType: {{ .metricType }}
+      {{- end }}
+      {{- if .authentication }}
+      authenticationRef:
+        name: {{ include "spartan.fullname" $ }}-worker-{{ $fullName }}-{{ .authentication.name }}
+      {{- end }}
+      metadata:
+        {{- toYaml .metadata | nindent 8 }}
+    {{- end }}
+---
+{{ end }}

--- a/charts/spartan/templates/worker-hpa.yaml
+++ b/charts/spartan/templates/worker-hpa.yaml
@@ -3,7 +3,13 @@
     {{- if .autoscaling.enabled }}
       {{- include "spartan.workerHpa" (dict "worker" $worker "Values" $.Values "Chart" $.Chart "Release" $.Release) }}
       {{- if lt $index (sub (len $.Values.workers) 1) }}
----
+      {{- end }}
+    {{- end }}
+  {{- end }}
+  {{- if (dig "keda" false $worker) }}
+    {{- if .keda.enabled }}
+      {{- include "spartan.workerKeda" (dict "worker" $worker "Values" $.Values "Chart" $.Chart "Release" $.Release) }}
+      {{- if lt $index (sub (len $.Values.workers) 1) }}
       {{- end }}
     {{- end }}
   {{- end }}

--- a/charts/spartan/values.yaml
+++ b/charts/spartan/values.yaml
@@ -160,7 +160,7 @@ autoscaling:
   ## minReplicas specifies minimum amount of Replicas
   minReplicas: 1
   ## maxReplicas specifies maximum amount of Replicas
-  maxReplicas: 100
+  maxReplicas: 10
   ## metrics specifies resource metrics utilization threshold
   metrics: []
   ## behaviour specifies separate scaling policies upon scale-up and scale-down
@@ -173,7 +173,9 @@ keda:
   ## minReplicas specifies minimum amount of Replicas
   minReplicas: 1
   ## maxReplicas specifies maximum amount of Replicas
-  maxReplicas: 100
+  maxReplicas: 10
+  ## pollingInterval specifies internal of polling the metrics
+  pollingInterval: 30
   ## controls the authentication between KEDA and the service it's autoscaling
   authentication: []
   #  - name: aws-irsa
@@ -290,7 +292,7 @@ extraEnvs: []
 #    value: 1.0.0
 
 ## workers enable users to deploy scalable and customizable worker components
-workers: []
+workers:
 #  - name: worker-1
 #    shell: /bin/bash
 #    command: "echo worker-1"
@@ -302,11 +304,18 @@ workers: []
 #      image: busybox
 #    podAnnotations: {}
 #    autoscaling:
-#      enabled: true
-#      minReplicas: 2
+#      enabled: false
+#      minReplicas: 1
 #      maxReplicas: 10
 #      targetCPUUtilizationPercentage: 80
 #      targetMemoryUtilizationPercentage: 80
+#    keda:
+#      enabled: false
+#      minReplicas: 1
+#      maxReplicas: 10
+#      pollingInterval: 30
+#      authentication: []
+#      triggers: []
 #    extraEnvs:
 #      - name: SERVICE
 #        value: worker

--- a/charts/spartan/values.yaml
+++ b/charts/spartan/values.yaml
@@ -292,7 +292,7 @@ extraEnvs: []
 #    value: 1.0.0
 
 ## workers enable users to deploy scalable and customizable worker components
-workers:
+workers: []
 #  - name: worker-1
 #    shell: /bin/bash
 #    command: "echo worker-1"

--- a/test/values.yaml
+++ b/test/values.yaml
@@ -161,6 +161,7 @@ keda:
   enabled: true
   minReplicas: 1
   maxReplicas: 100
+  pollingInterval: 30
   authentication:
     - name: aws-irsa
       podIdentity:
@@ -256,6 +257,20 @@ workers:
     extraEnvs:
       - name: SERVICE
         value: worker
+    keda:
+      enabled: true
+      minReplicas: 1
+      maxReplicas: 100
+      pollingInterval: 30
+      triggers:
+        - type: cpu
+          metricType: Utilization
+          metadata:
+            value: "80"
+        - type: memory
+          metricType: AverageValue
+          metadata:
+            value: "80"
   - name: worker-2
     shell: /bin/bash
     command: "echo worker-2"
@@ -269,7 +284,24 @@ workers:
     extraEnvs:
       - name: SERVICE
         value: worker
-
+    keda:
+      enabled: true
+      minReplicas: 1
+      maxReplicas: 100
+      pollingInterval: 30
+      authentication:
+        - name: aws-irsa
+          podIdentity:
+            provider: aws
+            identityOwner: workload
+      triggers:
+        - type: aws-sqs-queue
+          authentication:
+            name: aws-irsa
+          metadata:
+            queueURL: https://sqs.us-west-2.amazonaws.com/000000000000/keda
+            queueLength: "5"
+            awsRegion: us-west-2
 hooks:
   - name: "ls"
     hookTypes: "post-install,post-upgrade"


### PR DESCRIPTION
## Summary
Add `keda` configuration for worker jobs

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: --->

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which does not change existing behavior or add new functionality)
- [ ] Library update (non-breaking change that will update one or more libraries to newer versions)
- [ ] Domestic (documentation, non-breaking change that doesn't change code behavior, can skip testing)

## Test Plan:
`values.yaml`
```
workers:
  - name: worker-1
    shell: /bin/bash
    command: "echo worker-1"
    customImage:
      enabled: true
      image: busybox
    replicaCount: 1
    terminationGracePeriodSeconds: 180
    resources: {}
    podAnnotations: {}
    extraEnvs:
      - name: SERVICE
        value: worker
    keda:
      enabled: true
      minReplicas: 1
      maxReplicas: 100
      pollingInterval: 30
      triggers:
        - type: cpu
          metricType: Utilization
          metadata:
            value: "80"
        - type: memory
          metricType: AverageValue
          metadata:
            value: "80"
  - name: worker-2
    shell: /bin/bash
    command: "echo worker-2"
    customImage:
      enabled: true
      image: busybox
    replicaCount: 1
    terminationGracePeriodSeconds: 180
    resources: {}
    podAnnotations: {}
    extraEnvs:
      - name: SERVICE
        value: worker
    keda:
      enabled: true
      minReplicas: 1
      maxReplicas: 100
      pollingInterval: 30
      authentication:
        - name: aws-irsa
          podIdentity:
            provider: aws
            identityOwner: workload
      triggers:
        - type: aws-sqs-queue
          authentication:
            name: aws-irsa
          metadata:
            queueURL: https://sqs.us-west-2.amazonaws.com/000000000000/keda
            queueLength: "5"
            awsRegion: us-west-2
```

Outputs
```
# Source: spartan/templates/worker-hpa.yaml
apiVersion: keda.sh/v1alpha1
kind: ScaledObject
metadata:
  name: nginx-spartan-worker-worker-1
spec:
  minReplicaCount: 1
  maxReplicaCount: 100
  pollingInterval: 30
  scaleTargetRef:
    name: nginx-spartan-worker-worker-1
  triggers:
    - type: cpu
      metricType: Utilization
      metadata:
        value: "80"
    - type: memory
      metricType: AverageValue
      metadata:
        value: "80"
---
# Source: spartan/templates/worker-hpa.yaml
apiVersion: keda.sh/v1alpha1
kind: ScaledObject
metadata:
  name: nginx-spartan-worker-worker-2
spec:
  minReplicaCount: 1
  maxReplicaCount: 100
  pollingInterval: 30
  scaleTargetRef:
    name: nginx-spartan-worker-worker-2
  triggers:
    - type: aws-sqs-queue
      authenticationRef:
        name: nginx-spartan-worker-worker-2-aws-irsa
      metadata:
        awsRegion: us-west-2
        queueLength: "5"
        queueURL: https://sqs.us-west-2.amazonaws.com/000000000000/keda
---
# Source: spartan/templates/worker-hpa.yaml
apiVersion: keda.sh/v1alpha1
kind: TriggerAuthentication
metadata:
  name: nginx-spartan-worker-worker-2-aws-irsa
spec:
  podIdentity:
    provider: aws
    identityOwner: workload
```
## Jira Issues:
https://www.notion.so/c0x12c/EKS-Custom-metrics-to-support-HPA-17901fb05bf1808e881df4844ba80eca?pvs=4