### PR TITLE
feat: transfer the ownership of hpa to a scaledObject

### DIFF
--- a/charts/spartan/CHANGELOG.md
+++ b/charts/spartan/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.9](https://github.com/spartan-stratos/helm-charts/releases/tag/spartan-0.1.9) (2025-03-18)
+### Features
+* Enable transfer of HPA ownership in `keda` ScaledObject
+
 ## [0.1.8](https://github.com/spartan-stratos/helm-charts/releases/tag/spartan-0.1.8) (2025-01-22)
 ### Features
 * Add the `keda` configuration to support autoscaling by using [Keda](https://keda.sh/)

--- a/charts/spartan/Chart.yaml
+++ b/charts/spartan/Chart.yaml
@@ -15,10 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.8
-
+version: 0.1.9
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.1.8
+appVersion: 0.1.9

--- a/charts/spartan/templates/_worker-hpa.tpl
+++ b/charts/spartan/templates/_worker-hpa.tpl
@@ -2,7 +2,7 @@
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ include "spartan.fullname" $ }}-worker-{{ .worker.name}}
+  name: {{ include "spartan.fullname" $ }}-worker-{{ .worker.name }}
   labels:
     {{- include "spartan.labels" $ | nindent 4 }}
     tier: "worker"
@@ -10,7 +10,7 @@ spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ include "spartan.fullname" $ }}-worker-{{ .worker.name}}
+    name: {{ include "spartan.fullname" $ }}-worker-{{ .worker.name }}
   minReplicas: {{ .worker.autoscaling.minReplicas }}
   maxReplicas: {{ .worker.autoscaling.maxReplicas }}
   metrics:

--- a/charts/spartan/templates/_worker-keda.tpl
+++ b/charts/spartan/templates/_worker-keda.tpl
@@ -15,12 +15,21 @@ apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:
   name: {{ include "spartan.fullname" $ }}-worker-{{ $fullName }}
+  {{- if and .worker.autoscaling (hasKey .worker.autoscaling "enabled") .worker.autoscaling.enabled }}
+  annotations:
+    scaledobject.keda.sh/transfer-hpa-ownership: "true"
+  {{- end }}
 spec:
-  minReplicaCount: {{ .worker.keda.minReplicas}}
-  maxReplicaCount: {{ .worker.keda.maxReplicas}}
-  pollingInterval: {{ .worker.keda.pollingInterval}}
+  minReplicaCount: {{ .worker.keda.minReplicas }}
+  maxReplicaCount: {{ .worker.keda.maxReplicas }}
+  pollingInterval: {{ .worker.keda.pollingInterval }}
   scaleTargetRef:
-    name: {{ include "spartan.fullname" $ }}-worker-{{ .worker.name}}
+    name: {{ include "spartan.fullname" $ }}-worker-{{ .worker.name }}
+  {{- if and .worker.autoscaling (hasKey .worker.autoscaling "enabled") .worker.autoscaling.enabled }}
+  advanced:
+    horizontalPodAutoscalerConfig:
+      name: {{ include "spartan.fullname" $ }}-worker-{{ .worker.name }}
+  {{- end }}
   triggers:
     {{- range .worker.keda.triggers }}
     - type: {{ .type }}

--- a/charts/spartan/templates/keda.yaml
+++ b/charts/spartan/templates/keda.yaml
@@ -15,12 +15,21 @@ apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:
   name: {{ $fullName }}
+  {{- if .Values.autoscaling.enabled }}
+  annotations:
+    scaledobject.keda.sh/transfer-hpa-ownership: "true"
+  {{- end }}
 spec:
-  minReplicaCount: {{ .Values.keda.minReplicas}}
-  maxReplicaCount: {{ .Values.keda.maxReplicas}}
-  pollingInterval: {{ .Values.keda.pollingInterval}}
+  minReplicaCount: {{ .Values.keda.minReplicas }}
+  maxReplicaCount: {{ .Values.keda.maxReplicas }}
+  pollingInterval: {{ .Values.keda.pollingInterval }}
   scaleTargetRef:
     name: {{ $fullName }}
+  {{- if .Values.autoscaling.enabled }}
+  advanced:
+    horizontalPodAutoscalerConfig:
+      name: {{ include "spartan.fullname" . }}
+  {{- end }}
   triggers:
     {{- range .Values.keda.triggers }}
     - type: {{ .type }}

--- a/test/values.yaml
+++ b/test/values.yaml
@@ -257,6 +257,36 @@ workers:
     extraEnvs:
       - name: SERVICE
         value: worker
+    autoscaling:
+      enabled: true
+      minReplicas: 1
+      maxReplicas: 100
+      metrics:
+        - type: Resource
+          resource:
+            name: cpu
+            target:
+              type: Utilization
+              averageUtilization: 80
+        - type: Resource
+          resource:
+            name: memory
+            target:
+              type: Utilization
+              averageUtilization: 80
+      behavior:
+        scaleUp:
+          stabilizationWindowSeconds: 300
+          policies:
+            - type: Percent
+              value: 100
+              periodSeconds: 120
+        scaleDown:
+          stabilizationWindowSeconds: 300
+          policies:
+            - type: Percent
+              value: 50
+              periodSeconds: 60
     keda:
       enabled: true
       minReplicas: 1


### PR DESCRIPTION
## Summary

### Why
- Currently, Keda’s ScaledObject cannot be deployed if an existing Horizontal Pod Autoscaler (HPA) is present in the cluster. However, Keda provides a way to take ownership of an existing HPA by adding the following annotations and configuration:

```
metadata:
  annotations:
    scaledobject.keda.sh/transfer-hpa-ownership: "true"
spec:
   advanced:
      horizontalPodAutoscalerConfig:
        name: {name-of-hpa-resource}
```

Reference: https://keda.sh/docs/2.12/concepts/scaling-deployments/#transfer-ownership-of-an-existing-hpa

### What
- Modify the Helm chart to dynamically transfer ownership of an existing HPA to the new ScaledObject when autoscaling is enabled.
```
 {{- if .worker.autoscaling.enabled }}
  annotations:
    scaledobject.keda.sh/transfer-hpa-ownership: "true"
  {{- end }}
......
......
  {{- if .worker.autoscaling.enabled }}
  advanced:
    horizontalPodAutoscalerConfig:
      name: {{ include "spartan.fullname" $ }}-worker-{{ .worker.name }}
  {{- end }}
```

### Solution
- Update the Helm chart to check if autoscaling is enabled (.worker.autoscaling.enabled).
- If enabled, add the necessary annotation and configuration to transfer ownership of the HPA to Keda’s ScaledObject.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: --->

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which does not change existing behavior or add new functionality)
- [ ] Library update (non-breaking change that will update one or more libraries to newer versions)
- [ ] Domestic (documentation, non-breaking change that doesn't change code behavior, can skip testing)

## Test Plan:
Helm check 

## Jira Issues:
<!--- Link to your YouTrack ticket --->
