### PR TITLE
feat: add preStop hook and volumes for deployments

### DIFF
--- a/charts/spartan/CHANGELOG.md
+++ b/charts/spartan/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.1.14](https://github.com/spartan-stratos/helm-charts/releases/tag/spartan-0.1.14) (2025-05-22)
+### Features
+* Added support for custom `volumes` in `values.yaml`, allowing users to define and mount arbitrary volumes for `deployment.yaml`, including hostPath volumes.
 
 ## [0.1.13](https://github.com/spartan-stratos/helm-charts/releases/tag/spartan-0.1.13) (2025-05-22)
 ### Features

--- a/charts/spartan/CHANGELOG.md
+++ b/charts/spartan/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ## [0.1.14](https://github.com/spartan-stratos/helm-charts/releases/tag/spartan-0.1.14) (2025-05-22)
 ### Features
 * Added support for custom `volumes` in `values.yaml`, allowing users to define and mount arbitrary volumes for `deployment.yaml`, including hostPath volumes.
+* Added a preStop hook which will execute after the pods got signal to be terminated. After that it will execute the script defined in `Values.lifecycle.preStop.command`. By using that, we should add a sleep timeout for about `10s` to `30s` to make sure pod could successfully complete request before terminated 
 
 ## [0.1.13](https://github.com/spartan-stratos/helm-charts/releases/tag/spartan-0.1.13) (2025-05-22)
 ### Features

--- a/charts/spartan/Chart.yaml
+++ b/charts/spartan/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.13
+version: 0.1.14
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.1.13
+appVersion: 0.1.14

--- a/charts/spartan/templates/deployment.yaml
+++ b/charts/spartan/templates/deployment.yaml
@@ -142,7 +142,7 @@ spec:
             - name: {{ .claimName }}-volume
               mountPath: {{ .mountPath }}
           {{- end }}
-          {{- range .Values.volmueMounts }}
+          {{- range .Values.volumeMounts }}
             - name: {{ .name }}
               mountPath: {{ .mountPath }}
           {{- end }}

--- a/charts/spartan/templates/deployment.yaml
+++ b/charts/spartan/templates/deployment.yaml
@@ -181,3 +181,13 @@ spec:
           persistentVolumeClaim:
             claimName: {{ .claimName }}
       {{- end }}
+      {{- range .Values.volumes }}
+        - name: {{ .name }}
+        {{- if .hostPath }}
+          hostPath:
+            path: {{ .hostPath.path }}
+          {{- if .hostPath.type }}
+            type: {{ .hostPath.type }}
+          {{- end }}
+        {{- end }}
+      {{- end }}

--- a/charts/spartan/templates/deployment.yaml
+++ b/charts/spartan/templates/deployment.yaml
@@ -51,6 +51,12 @@ spec:
             - name: http
               containerPort: {{ .Values.containerPort | default 80 }}
               protocol: TCP
+          {{- if .Values.lifecycle.preStop.enabled }}
+          lifecycle:
+            preStop:
+              exec:
+                command: {{ toJson .Values.lifecycle.preStop.exec.command }}
+          {{- end }}
           {{- if .Values.args | len }}
           args: {{- toYaml .Values.args | nindent 12 }}
           {{- end }}

--- a/charts/spartan/templates/deployment.yaml
+++ b/charts/spartan/templates/deployment.yaml
@@ -142,6 +142,10 @@ spec:
             - name: {{ .claimName }}-volume
               mountPath: {{ .mountPath }}
           {{- end }}
+          {{- range .Values.volmueMounts }}
+            - name: {{ .name }}
+              mountPath: {{ .mountPath }}
+          {{- end }}
         {{- range $sidecar := .Values.sidecars }}
         {{ include "sidecar.template" (dict "sidecar" $sidecar "Values" $.Values "Chart" $.Chart "Release" $.Release) | indent 8 }}
         {{- end }}

--- a/charts/spartan/values.yaml
+++ b/charts/spartan/values.yaml
@@ -60,6 +60,11 @@ securityContext: {}
 #  runAsNonRoot: true
 #  runAsUser: 1000
 
+volumeMounts: []
+#   - name: app-logs
+#     mountPath: /var/log/application
+#
+
 ## volumes is for customizing volumes with hostPath, which will shared volumes with other pods in managed node
 volumes: []
 #   - name: app-logs

--- a/charts/spartan/values.yaml
+++ b/charts/spartan/values.yaml
@@ -65,7 +65,7 @@ volumeMounts: []
 #     mountPath: /var/log/application
 #
 
-## volumes is for customizing volumes with hostPath, which will shared volumes with other pods in managed node
+## volumes allows defining custom pod volumes
 volumes: []
 #   - name: app-logs
 #     hostPath:

--- a/charts/spartan/values.yaml
+++ b/charts/spartan/values.yaml
@@ -29,11 +29,11 @@ fullnameOverride: ""
 appNameLabel: ""
 
 #lifeCycle preStop will execute a script before the pod started to be terminated
-lifecycle: {}
-#  preStop:
-#    enabled: true
-#    exec:
-#      command: ["/bin/sh", "-c", "echo PreStop Hook; sleep 10"]
+lifecycle:
+  preStop:
+    enabled: false
+#   exec:
+#     command: ["/bin/sh", "-c", "echo PreStop Hook; sleep 10"]
 
 serviceAccount:
   ## create specifies whether a service account should be created

--- a/charts/spartan/values.yaml
+++ b/charts/spartan/values.yaml
@@ -28,6 +28,13 @@ fullnameOverride: ""
 ## appNameLabel is used for app.kubernetes.io/name k8s resources label
 appNameLabel: ""
 
+#lifeCycle preStop will execute a script before the pod started to be terminated
+lifecycle: {}
+#  preStop:
+#    enabled: true
+#    exec:
+#      command: ["/bin/sh", "-c", "echo PreStop Hook; sleep 10"]
+
 serviceAccount:
   ## create specifies whether a service account should be created
   create: false

--- a/charts/spartan/values.yaml
+++ b/charts/spartan/values.yaml
@@ -53,6 +53,13 @@ securityContext: {}
 #  runAsNonRoot: true
 #  runAsUser: 1000
 
+## volumes is for customizing volumes with hostPath, which will shared volumes with other pods in managed node
+volumes: []
+#   - name: app-logs
+#     hostPath:
+#       path: /var/log/application
+#       type: DirectoryOrCreate
+
 service:
   ## annotations specifies service annotations
   annotations: {}


### PR DESCRIPTION
## Summary
* Added support for custom `volumes` in `values.yaml`, allowing users to define and mount arbitrary volumes for `deployment.yaml`, including hostPath volumes.
* Added a preStop hook which will execute after the pods got signal to be terminated. After that it will execute the script defined in `Values.lifecycle.preStop.command`. By using that, we should add a sleep timeout for about `10s` to `30s` to make sure pod could successfully complete request before terminated 
<!--- Summary of changes --->

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: --->

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which does not change existing behavior or add new functionality)
- [ ] Library update (non-breaking change that will update one or more libraries to newer versions)
- [ ] Domestic (documentation, non-breaking change that doesn't change code behavior, can skip testing)

## Test Plan:
<!--- How do you test your changes? (unit test, integration test, dev test) or skip_test if it's not applicable  --->

## Jira Issues:
<!--- Link to your YouTrack ticket --->
