### PR TITLE
feat: add support for terminationGracePeriodSeconds in Deployment

### DIFF
--- a/charts/spartan/CHANGELOG.md
+++ b/charts/spartan/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.20](https://github.com/spartan-stratos/helm-charts/releases/tag/spartan-0.1.20) (2026-04-01)
+
+### Features
+
+* Add optional top-level `terminationGracePeriodSeconds` support for the main application Deployment.
+
 ## [0.1.19](https://github.com/spartan-stratos/helm-charts/releases/tag/spartan-0.1.19) (2026-03-23)
 
 ### Bug Fixes

--- a/charts/spartan/Chart.yaml
+++ b/charts/spartan/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.19
+version: 0.1.20
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.1.19
+appVersion: 0.1.20

--- a/charts/spartan/templates/deployment.yaml
+++ b/charts/spartan/templates/deployment.yaml
@@ -34,8 +34,8 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "spartan.serviceAccountName" . }}
-      {{- with .Values.terminationGracePeriodSeconds }}
-      terminationGracePeriodSeconds: {{ . }}
+      {{- if not (eq .Values.terminationGracePeriodSeconds nil) }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}

--- a/charts/spartan/templates/deployment.yaml
+++ b/charts/spartan/templates/deployment.yaml
@@ -34,6 +34,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "spartan.serviceAccountName" . }}
+      {{- with .Values.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ . }}
+      {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       {{- if .Values.datadog.enabled }}

--- a/charts/spartan/values.yaml
+++ b/charts/spartan/values.yaml
@@ -35,6 +35,11 @@ lifecycle:
 #   exec:
 #     command: ["/bin/sh", "-c", "echo PreStop Hook; sleep 10"]
 
+## terminationGracePeriodSeconds optionally sets pod shutdown grace period
+## for the main application Deployment. When null, Kubernetes uses the
+## cluster default for pods.
+terminationGracePeriodSeconds: null
+
 serviceAccount:
   ## create specifies whether a service account should be created
   create: false


### PR DESCRIPTION
## Summary

This PR adds optional `terminationGracePeriodSeconds` support to the Spartan Helm chart's main application Deployment. This enables graceful pod shutdown for long-running workloads by allowing Kubernetes pods to complete in-flight requests before termination.

### Why

When Kubernetes terminates a pod during deployments or node drains, pods with long-running workloads (like PDF analysis, device counting, or SSE streams) may be killed before completing their work. The `terminationGracePeriodSeconds` setting controls how long Kubernetes waits for a pod to gracefully shut down after sending SIGTERM.

Previously, the chart did not expose this setting, leaving pods to use the cluster default (typically 30 seconds), which may not be sufficient for AI/ML workloads with lengthy inference times.

### What

Added optional `terminationGracePeriodSeconds` configuration to:

- **`charts/spartan/templates/deployment.yaml`** — Conditionally renders `terminationGracePeriodSeconds` in the Deployment spec when the value is set
- **`charts/spartan/values.yaml`** — Added documentation and default (`null`) for the new top-level key
- **`charts/spartan/Chart.yaml`** — Bumped chart version to `0.1.20`
- **`charts/spartan/CHANGELOG.md`** — Documented the new feature release

### Solution

Used Helm's conditional rendering pattern (`{{- with .Values.terminationGracePeriodSeconds }}`) to only include the field when explicitly set, preserving backward compatibility with existing deployments that rely on the cluster default.

When set, the value propagates directly to the pod template's `terminationGracePeriodSeconds` field:

```yaml
spec:
  template:
    spec:
      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
```

This aligns with the Phase 1 drain behavior in `service-ai`, where pods should be given sufficient time to complete in-flight requests before forced termination.

## Types of Changes

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which does not change existing behavior or add new functionality)
- [ ] Library update (non-breaking change that will update one or more libraries to newer versions)
- [x] Domestic (documentation, non-breaking change that doesn't change code behavior, can skip testing)

## Test Plan

### Manual Testing

1. Render the chart with `terminationGracePeriodSeconds: 60` and verify the field appears in the Deployment spec
2. Render the chart with `terminationGracePeriodSeconds: null` (default) and verify the field is absent from the Deployment spec
3. Deploy to a test Kubernetes cluster and verify pod terminates gracefully within the configured period

### Chart Validation

```bash
helm lint charts/spartan
helm template my-release charts/spartan --set terminationGracePeriodSeconds=60
```

## Jira Issues

- Related to **Phase 1: Stop silent hangs** — service-ai #68
- Enables graceful shutdown configuration for `service-ai` deployments using the Spartan chart
