### PR TITLE
feat: add multi-port service support

### DIFF
--- a/charts/spartan/CHANGELOG.md
+++ b/charts/spartan/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.21](https://github.com/spartan-stratos/helm-charts/releases/tag/spartan-0.1.21) (2026-04-03)
+
+### Features
+
+* Add optional `service.ports` list for multi-port Service support.
+  * When `service.ports` is non-empty, the Service renders all listed ports.
+  * When empty or unset, falls back to the existing `service.port` single-port behavior (no breaking change).
+* Add `spartan.servicePrimaryPort` helper used by Ingress, test-connection, and NOTES.
+
 ## [0.1.20](https://github.com/spartan-stratos/helm-charts/releases/tag/spartan-0.1.20) (2026-04-01)
 
 ### Features

--- a/charts/spartan/Chart.yaml
+++ b/charts/spartan/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.20
+version: 0.1.21
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.1.20
+appVersion: 0.1.21

--- a/charts/spartan/templates/NOTES.txt
+++ b/charts/spartan/templates/NOTES.txt
@@ -13,7 +13,7 @@
      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
            You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "spartan.fullname" . }}'
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "spartan.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
-  echo http://$SERVICE_IP:{{ .Values.service.port }}
+  echo http://$SERVICE_IP:{{ include "spartan.servicePrimaryPort" . }}
 {{- else if contains "ClusterIP" .Values.service.type }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "spartan.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")

--- a/charts/spartan/templates/_helpers.tpl
+++ b/charts/spartan/templates/_helpers.tpl
@@ -189,6 +189,17 @@ Get list of resources type
 {{- end }}
 
 {{- /*
+Primary service port (first entry from service.ports, or legacy service.port)
+*/}}
+{{- define "spartan.servicePrimaryPort" -}}
+{{- if .Values.service.ports -}}
+{{- (index .Values.service.ports 0).port -}}
+{{- else -}}
+{{- .Values.service.port | default 80 -}}
+{{- end -}}
+{{- end -}}
+
+{{- /*
 Merge extraEnvs
 */}}
 {{- define "spartan.extraEnvs" -}}

--- a/charts/spartan/templates/ingress.yaml
+++ b/charts/spartan/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "spartan.fullname" . -}}
-{{- $svcPort := .Values.service.port -}}
+{{- $svcPort := include "spartan.servicePrimaryPort" . -}}
 {{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
   {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
   {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className }}

--- a/charts/spartan/templates/service.yaml
+++ b/charts/spartan/templates/service.yaml
@@ -16,9 +16,18 @@ metadata:
 spec:
   type: {{ .Values.service.type }}
   ports:
+    {{- if .Values.service.ports }}
+    {{- range .Values.service.ports }}
+    - port: {{ .port }}
+      targetPort: {{ .targetPort | default .port }}
+      protocol: {{ .protocol | default "TCP" }}
+      name: {{ .name }}
+    {{- end }}
+    {{- else }}
     - port: {{ .Values.service.port | default 80 }}
       targetPort: {{ .Values.containerPort | default 80 }}
       protocol: {{ .Values.service.protocol | default "TCP" }}
       name: {{ .Values.service.name | default "http" }}
+    {{- end }}
   selector:
     {{- include "spartan.selectorLabels" . | nindent 4 }}

--- a/charts/spartan/templates/tests/test-connection.yaml
+++ b/charts/spartan/templates/tests/test-connection.yaml
@@ -12,6 +12,6 @@ spec:
     - name: wget
       image: busybox
       command: ['wget']
-      args: ['{{ include "spartan.fullname" . }}:{{ .Values.service.port }}']
+      args: ['{{ include "spartan.fullname" . }}:{{ include "spartan.servicePrimaryPort" . }}']
   restartPolicy: Never
 {{- end }}

--- a/charts/spartan/values.yaml
+++ b/charts/spartan/values.yaml
@@ -82,11 +82,21 @@ service:
   annotations: {}
   ## type specifies the service type
   type: ClusterIP
-  ## port specifies the service port
+  ## port specifies the service port (legacy single-port mode)
   port: 80
   ## protocol specifies the service protocol
   protocol: TCP
   ## name specifies the service name
+  ## ports overrides the single-port config above with a full list when non-empty
+  ## Example:
+  ##   ports:
+  ##     - name: http
+  ##       port: 80
+  ##       targetPort: 8080
+  ##     - name: jobrunr
+  ##       port: 3000
+  ##       targetPort: 3000
+  ports: []
   name: http
 
 gcp:


### PR DESCRIPTION
## Summary
### Features

* Add optional `service.ports` list for multi-port Service support.
  * When `service.ports` is non-empty, the Service renders all listed ports.
  * When empty or unset, falls back to the existing `service.port` single-port behavior (no breaking change).
* Add `spartan.servicePrimaryPort` helper used by Ingress, test-connection, and NOTES.
<!--- Summary of changes --->

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: --->

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which does not change existing behavior or add new functionality)
- [ ] Library update (non-breaking change that will update one or more libraries to newer versions)
- [ ] Domestic (documentation, non-breaking change that doesn't change code behavior, can skip testing)

## Test Plan:
<!--- How do you test your changes? (unit test, integration test, dev test) or skip_test if it's not applicable  --->

## Jira Issues:
<!--- Link to your YouTrack ticket --->
