### PR TITLE
feat(spartan): add global podLabels to spartan chart

### DIFF
--- a/charts/spartan/CHANGELOG.md
+++ b/charts/spartan/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.23](https://github.com/spartan-stratos/helm-charts/releases/tag/spartan-0.1.23) (2026-04-28)
+
+### Features
+
+* Add global `podLabels` support across Spartan pod templates
+  * Applies to the main Deployment, workers, CronJobs, and hooks
+  * Keeps workload selectors unchanged while allowing extra operational labels on pods
+
 ## [0.1.22](https://github.com/spartan-stratos/helm-charts/releases/tag/spartan-0.1.22) (2026-04-04)
 * Add optional per-path `servicePort` in Ingress for routing different paths to different Service ports.
 
@@ -57,8 +65,8 @@ All notable changes to this project will be documented in this file.
 ### Features
 
 * Added optional fields on CronJob.spec and jobTemplate.spec:
-  
-  * concurrencyPolicy, startingDeadlineSeconds, suspend, timeZone 
+
+  * concurrencyPolicy, startingDeadlineSeconds, suspend, timeZone
   * backoffLimit, activeDeadlineSeconds, ttlSecondsAfterFinished, completions, parallelism
 
 ## [0.1.15](https://github.com/spartan-stratos/helm-charts/releases/tag/spartan-0.1.15) (2025-08-20)

--- a/charts/spartan/Chart.yaml
+++ b/charts/spartan/Chart.yaml
@@ -15,9 +15,17 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.22
+<<<<<<< HEAD
+version: 0.1.23
+=======
+version: 0.1.20
+>>>>>>> c791214 (update spartan release notes)
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.1.22
+<<<<<<< HEAD
+appVersion: 0.1.23
+=======
+appVersion: 0.1.20
+>>>>>>> c791214 (update spartan release notes)

--- a/charts/spartan/Chart.yaml
+++ b/charts/spartan/Chart.yaml
@@ -15,17 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-<<<<<<< HEAD
 version: 0.1.23
-=======
-version: 0.1.20
->>>>>>> c791214 (update spartan release notes)
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-<<<<<<< HEAD
 appVersion: 0.1.23
-=======
-appVersion: 0.1.20
->>>>>>> c791214 (update spartan release notes)

--- a/charts/spartan/README.md
+++ b/charts/spartan/README.md
@@ -145,6 +145,16 @@ deploymentAnnotations:
   "backup.velero.io/backup-volumes": "data"
 ```
 
+## Global Pod Labels
+
+The spartan chart supports adding custom labels to every pod template it renders through the `podLabels` configuration. These labels are applied to application deployments, workers, cronjobs, and hooks without changing workload selectors.
+
+```yaml
+podLabels:
+  team: platform
+  environment: production
+```
+
 ## Configuration
 
 The following table lists the configurable parameters of the **spartan chart** and their default values.
@@ -209,6 +219,7 @@ The following table lists the configurable parameters of the **spartan chart** a
 | pdb.minAvailable                                                                                                                                                  | Minimum number/percentage of pods that should remain scheduled                                                                                     | 1            |
 | pdb.maxUnavailable                                                                                                                                                | Maximum number/percentage of pods that may be made unavailable                                                                                     | ""           |
 | podAnnotations                                                                                                                                                    | Pods annotations                                                                                                                                   | {}           |
+| podLabels                                                                                                                                                         | Global labels added to all pod templates                                                                                                           | {}           |
 | podSecurityContext                                                                                                                                                | Custom pod security context for spartan pod                                                                                                        | {}           |
 | readinessProbe                                                                                                                                                    | Readiness Probe initial delay and timeout                                                                                                          | {}           |
 | replicaCount                                                                                                                                                      | Number of replicas                                                                                                                                 | 1            |

--- a/charts/spartan/templates/_cronjob.tpl
+++ b/charts/spartan/templates/_cronjob.tpl
@@ -54,6 +54,7 @@ spec:
           labels:
             {{- include "spartan.cronjobLabels" $ | nindent 12 }}
             tier: "cronjob"
+            {{- include "spartan.podLabels" . | nindent 12 }}
         spec:
           {{- with .Values.imagePullSecrets }}
           imagePullSecrets:

--- a/charts/spartan/templates/_helpers.tpl
+++ b/charts/spartan/templates/_helpers.tpl
@@ -101,6 +101,15 @@ app.kubernetes.io/name: {{ include "spartan.name" . }}-{{ .cronjob.name }}
 app.kubernetes.io/instance: {{ .Release.Name }}-cronjob
 {{- end }}
 
+{{/*
+Global pod labels
+*/}}
+{{- define "spartan.podLabels" -}}
+{{- with .Values.podLabels }}
+{{- toYaml . }}
+{{- end }}
+{{- end }}
+
 {{- /*
 Create the name of the service account to use
 */}}
@@ -225,4 +234,3 @@ Merge extraEnvs
   {{- end -}}
   {{- toYaml $merged }}
 {{- end -}}
-

--- a/charts/spartan/templates/_hook.tpl
+++ b/charts/spartan/templates/_hook.tpl
@@ -32,6 +32,7 @@ spec:
       labels:
         {{- include "spartan.hookLabels" . | nindent 8 }}
         tier: "hook"
+        {{- include "spartan.podLabels" . | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/spartan/templates/_worker.tpl
+++ b/charts/spartan/templates/_worker.tpl
@@ -28,6 +28,7 @@ spec:
       labels:
         {{- include "spartan.workerLabels" $ | nindent 8 }}
         tier: "worker"
+        {{- include "spartan.podLabels" . | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/spartan/templates/deployment.yaml
+++ b/charts/spartan/templates/deployment.yaml
@@ -28,6 +28,7 @@ spec:
       labels:
         {{- include "spartan.selectorLabels" . | nindent 8 }}
         tier: "application"
+        {{- include "spartan.podLabels" . | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/spartan/tests/deployment_test.yaml
+++ b/charts/spartan/tests/deployment_test.yaml
@@ -1,0 +1,20 @@
+suite: "Deployment template tests"
+
+templates:
+  - "templates/deployment.yaml"
+
+tests:
+  - it: "renders global podLabels on the main deployment pod template"
+    set:
+      podLabels:
+        team: platform
+        environment: production
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: spec.template.metadata.labels.team
+          value: platform
+      - equal:
+          path: spec.template.metadata.labels.environment
+          value: production

--- a/charts/spartan/tests/hook_test.yaml
+++ b/charts/spartan/tests/hook_test.yaml
@@ -90,3 +90,30 @@ tests:
           value: keep
       - notExists:
           path: metadata.annotations["helm.sh/hook-delete-policy"]
+
+  - it: "renders global podLabels on hook pod templates"
+    set:
+      podLabels:
+        team: platform
+        environment: production
+      hooks:
+        - name: migration
+          hookTypes: pre-install
+          shell: /bin/sh
+          commands:
+            - echo migration
+          resources: {}
+          customImage:
+            enabled: false
+            image: busybox
+          restartPolicy: Never
+          backoffLimit: 0
+    asserts:
+      - isKind:
+          of: Job
+      - equal:
+          path: spec.template.metadata.labels.team
+          value: platform
+      - equal:
+          path: spec.template.metadata.labels.environment
+          value: production

--- a/charts/spartan/values.yaml
+++ b/charts/spartan/values.yaml
@@ -52,6 +52,9 @@ serviceAccount:
 ## podAnnocations specify pods annotation
 podAnnotations: {}
 
+## podLabels specify global labels added to all pod templates
+podLabels: {}
+
 ## podSecurityContext is custom pod security context for spartan pod
 podSecurityContext: {}
   # fsGroup: 2000


### PR DESCRIPTION
## What changed
- added a new global `podLabels` value to the `spartan` chart
- rendered those labels into every pod template the chart creates: the main deployment, workers, cronjobs, and hooks
- documented the new value in the chart README
- added helm-unittest coverage for deployment and hook pod template labels

## Why
The chart already supported global `podAnnotations`, but it had no chart-wide way to attach additional labels to pod templates. That made it harder to apply common operational or organizational labels consistently across all workloads produced by the chart.

## Impact
Users can now set `podLabels` once in chart values and have those labels applied across all generated pod templates without changing any selectors.

## Root cause
Pod template labels were hardcoded per template and only included selector-style labels plus the workload tier. There was no shared helper or values entry for optional global pod labels.

## Validation
- `helm unittest charts/spartan`
- `helm template test-release charts/spartan --set podLabels.team=platform --set podLabels.environment=production`
