### PR TITLE
feat(spartan): add projected volume type support

### DIFF
--- a/charts/spartan/CHANGELOG.md
+++ b/charts/spartan/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.0](https://github.com/spartan-stratos/helm-charts/releases/tag/spartan-0.2.0) (2026-05-06)
+
+### Features
+
+* Add `projected` volume type support in the custom `volumes` list
+  * Enables Kubernetes projected ServiceAccountToken volumes required for GCP Workload Identity Federation (WIF)
+  * Previously unrecognised volume types silently fell back to `emptyDir`; `projected` sources are now rendered correctly
+
 ## [0.1.23](https://github.com/spartan-stratos/helm-charts/releases/tag/spartan-0.1.23) (2026-04-28)
 
 ### Features

--- a/charts/spartan/Chart.yaml
+++ b/charts/spartan/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.23
+version: 0.1.24
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.1.23
+appVersion: 0.1.24

--- a/charts/spartan/Chart.yaml
+++ b/charts/spartan/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.24
+version: 0.2.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.1.24
+appVersion: 0.2.0

--- a/charts/spartan/templates/deployment.yaml
+++ b/charts/spartan/templates/deployment.yaml
@@ -229,4 +229,9 @@ spec:
           persistentVolumeClaim:
             claimName: {{ .persistentVolumeClaim.claimName }}
         {{- end }}
+        {{- if .projected }}
+          projected:
+            sources:
+              {{- toYaml .projected.sources | nindent 14 }}
+        {{- end }}
       {{- end }}

--- a/test/values.yaml
+++ b/test/values.yaml
@@ -410,6 +410,19 @@ persistence:
   - claimName: "my-pvc"
     mountPath: "/data"
 
+volumes:
+  - name: gcp-sts-token
+    projected:
+      sources:
+        - serviceAccountToken:
+            audience: sts.googleapis.com
+            expirationSeconds: 3600
+            path: token
+
+volumeMounts:
+  - name: gcp-sts-token
+    mountPath: /var/run/secrets/sts
+
 sidecars:
   - name: datadog-agent
     image: datadog/agent


### PR DESCRIPTION
## Summary

- Adds `{{- if .projected }}` branch inside the `{{- range .Values.volumes }}` loop in `templates/deployment.yaml`
- Projected volumes (e.g. Kubernetes ServiceAccountToken for GCP Workload Identity Federation) were previously silently ignored, causing the pod to receive an `emptyDir` instead
- Bumps chart version to `0.1.24`

## Problem

When a service declares a `projected` volume in Helm values (required for GCP WIF to mint a ServiceAccountToken at a specific path), the spartan chart template had no handler for that volume type. The rendered manifest omitted the volume source entirely, and Kubernetes defaulted it to `emptyDir`. The token file was never written, causing:

```
java.io.IOException: Invalid credential location. The file at /var/run/secrets/sts/token does not exist.
```

## Change

```yaml
# charts/spartan/templates/deployment.yaml — inside {{- range .Values.volumes }}
{{- if .projected }}
  projected:
    sources:
      {{- toYaml .projected.sources | nindent 14 }}
{{- end }}
```

## Test plan

- [ ] Deploy a workload with a `projected` ServiceAccountToken volume in Helm values
- [ ] Confirm `kubectl describe pod` shows `Type: Projected` (not `EmptyDir`) for that volume
- [ ] Confirm the token file is present at the declared path inside the container