### PR TITLE
feat(strimzi-user-operator): externalSecret.enabled toggle (0.3.0)

### DIFF
--- a/charts/strimzi-user-operator/CHANGELOG.md
+++ b/charts/strimzi-user-operator/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this chart are documented in this file.
 
+## [0.3.0](https://github.com/spartan-stratos/helm-charts/releases/tag/strimzi-user-operator-0.3.0) (2026-05-14)
+
+### Features
+
+* `externalSecret.enabled` toggle (default `true`) — when set to `false`,
+  the chart skips rendering the `ExternalSecret` resource. The consumer
+  is then responsible for provisioning the JAAS-format K8s Secret
+  out-of-band (e.g. via Terraform `kubernetes_secret`). Useful for
+  clusters that do not run the ExternalSecrets operator.
+
+### Why
+
+The chart's ExternalSecret made ExternalSecrets a hard prerequisite.
+Some clusters intentionally don't run that operator (or run a different
+secret-sync mechanism). The toggle lets the chart work in both
+environments without forking.
+
 ## [0.2.0](https://github.com/spartan-stratos/helm-charts/releases/tag/strimzi-user-operator-0.2.0) (2026-05-14)
 
 ### Breaking changes

--- a/charts/strimzi-user-operator/Chart.yaml
+++ b/charts/strimzi-user-operator/Chart.yaml
@@ -13,5 +13,5 @@ description: |
   Manages Kafka ACL declaratively via KafkaUser CRDs. KafkaUser CRD
   instances live in the sibling `kafka-users` chart.
 type: application
-version: 0.2.0
+version: 0.3.0
 appVersion: "0.45.1"

--- a/charts/strimzi-user-operator/README.md
+++ b/charts/strimzi-user-operator/README.md
@@ -55,11 +55,20 @@ Provision them once via the consumer's Terraform / one-off kubectl
    ```
    https://github.com/strimzi/strimzi-kafka-operator/blob/0.45.1/install/cluster-operator/044-Crd-kafkauser.yaml
    ```
-3. **ExternalSecrets operator** installed cluster-wide
-   (`external-secrets.io/v1beta1` CRDs available).
-4. **`ClusterSecretStore`** (or `SecretStore` in the target namespace)
-   wired to AWS Secrets Manager via IRSA. The default `externalSecretStore.name`
-   is `aws-secrets-manager`; override if your store has a different name.
+3. **A K8s `Secret`** named per `mskAclAdminSecret.k8sSecretName` (default
+   `msk-acl-admin-creds`) holding a single key `admin.properties` with the
+   JAAS config the operator reads. Two ways to provision it:
+   - **`externalSecret.enabled: true` (default)** — requires the
+     ExternalSecrets operator (`external-secrets.io/v1beta1` CRDs)
+     installed cluster-wide, plus a `ClusterSecretStore`/`SecretStore`
+     wired to AWS Secrets Manager via IRSA (default store name
+     `aws-secrets-manager` — override via `externalSecretStore.name`).
+     The chart will render an `ExternalSecret` that syncs the credential
+     from AWS Secrets Manager into the K8s Secret.
+   - **`externalSecret.enabled: false`** — consumer creates the K8s
+     Secret directly (e.g. via Terraform `kubernetes_secret` that reads
+     the AWS Secrets Manager value and writes the JAAS properties).
+     Use this if the cluster does not run ExternalSecrets.
 
 ## Values
 
@@ -73,8 +82,9 @@ Provision them once via the consumer's Terraform / one-off kubectl
 | `mskBootstrapServersSaslScram` | string | `""` | MSK SASL/SCRAM bootstrap-broker list (comma-separated `host:9096`) |
 | `mskAclAdminSecret.awsSecretName` | string | `""` | Friendly name of the AWS Secrets Manager secret containing `username` + `password` JSON keys |
 | `mskAclAdminSecret.k8sSecretName` | string | `msk-acl-admin-creds` | Name of the K8s `Secret` ExternalSecrets renders into |
-| `externalSecretStore.kind` | string | `ClusterSecretStore` | `ClusterSecretStore` or `SecretStore` |
-| `externalSecretStore.name` | string | `aws-secrets-manager` | Name of the existing ExternalSecrets store binding |
+| `externalSecret.enabled` | bool | `true` | Render the `ExternalSecret` resource. Set `false` if the cluster does not run the ExternalSecrets operator — the consumer then provisions the K8s Secret out-of-band (e.g. Terraform). |
+| `externalSecretStore.kind` | string | `ClusterSecretStore` | Used only when `externalSecret.enabled` is `true`. `ClusterSecretStore` or `SecretStore`. |
+| `externalSecretStore.name` | string | `aws-secrets-manager` | Used only when `externalSecret.enabled` is `true`. Name of the existing ExternalSecrets store binding. |
 | `resources.*` | object | see `values.yaml` | CPU + memory requests/limits — operator is lightweight |
 | `fullReconciliationIntervalMs` | int | `120000` | Reconcile cadence (ms) — matches Strimzi default |
 

--- a/charts/strimzi-user-operator/templates/externalsecret-scram.yaml
+++ b/charts/strimzi-user-operator/templates/externalsecret-scram.yaml
@@ -1,12 +1,17 @@
-# Sync msk-acl-admin SCRAM credential from AWS Secrets Manager into a K8s
-# Secret the User Operator mounts as JAAS config.
+{{- if .Values.externalSecret.enabled -}}
+# Sync the operator's SCRAM admin credential from AWS Secrets Manager into a
+# K8s Secret. The operator mounts the resulting Secret as JAAS config via
+# STRIMZI_KAFKA_ADMIN_CLIENT_CONFIGURATION.
 #
-# The AWS secret format (created by aws_msk_scram_secret_association in
-# infra-terraform `modules/msk-scram-user`) is JSON:
-#   { "username": "msk-acl-admin", "password": "<random>" }
+# Requires the ExternalSecrets operator (https://external-secrets.io)
+# installed on the cluster. If your cluster does not run ExternalSecrets,
+# disable this template (set `externalSecret.enabled: false`) and provision
+# the K8s Secret out-of-band — e.g. via Terraform `kubernetes_secret` that
+# reads the AWS Secrets Manager value and writes the same JAAS properties.
 #
-# We render that as a JAAS-format properties file the operator reads via the
-# STRIMZI_KAFKA_ADMIN_CLIENT_CONFIGURATION env var.
+# Expected source-secret JSON payload (what aws_msk_scram_secret_association
+# stores in AWS Secrets Manager):
+#   { "username": "<scram-username>", "password": "<random>" }
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
@@ -42,3 +47,4 @@ spec:
       remoteRef:
         key: {{ .Values.mskAclAdminSecret.awsSecretName }}
         property: password
+{{- end -}}

--- a/charts/strimzi-user-operator/values.yaml
+++ b/charts/strimzi-user-operator/values.yaml
@@ -32,9 +32,23 @@ mskAclAdminSecret:
   awsSecretName: ""   # e.g. AmazonMSK_msk-acl-admin-dev-xxxxxx
   k8sSecretName: msk-acl-admin-creds
 
-# ExternalSecrets store reference — must point at an existing
-# ClusterSecretStore (or SecretStore) wired to AWS Secrets Manager in the
-# target cluster. This chart does not create the store.
+# Whether to render the `ExternalSecret` resource that syncs the SCRAM
+# admin credential from AWS Secrets Manager into the K8s Secret named in
+# `mskAclAdminSecret.k8sSecretName`.
+#
+# Set to `false` if the consumer's cluster does NOT run the ExternalSecrets
+# operator (https://external-secrets.io). When disabled, the consumer is
+# responsible for creating the K8s Secret out-of-band — e.g. via Terraform
+# `kubernetes_secret` that reads the AWS Secrets Manager value and writes a
+# JAAS-format `admin.properties` key. The operator will pick the Secret up
+# via `STRIMZI_KAFKA_ADMIN_CLIENT_CONFIGURATION` either way.
+externalSecret:
+  enabled: true
+
+# ExternalSecrets store reference (used only when `externalSecret.enabled`
+# is true) — must point at an existing ClusterSecretStore or SecretStore
+# wired to AWS Secrets Manager in the target cluster. This chart does not
+# create the store.
 externalSecretStore:
   kind: ClusterSecretStore
   name: aws-secrets-manager


### PR DESCRIPTION
## Summary

Make the chart deployable on clusters that do not run the
ExternalSecrets operator. Adds a top-level value:

```yaml
externalSecret:
  enabled: true   # default — render ExternalSecret resource
```

When set to `false`, the chart skips rendering `templates/externalsecret-scram.yaml`.
Consumer must then create the K8s Secret named per `mskAclAdminSecret.k8sSecretName`
(default `msk-acl-admin-creds`) out-of-band — for example, via Terraform:

```hcl
data "aws_secretsmanager_secret_version" "msk_acl_admin" {
  secret_id = "AmazonMSK_msk-acl-admin-dev"
}

resource "kubernetes_secret" "msk_acl_admin_creds" {
  metadata {
    name      = "msk-acl-admin-creds"
    namespace = "kafka-acl"
  }
  data = {
    "admin.properties" = <<-EOT
      security.protocol=SASL_SSL
      sasl.mechanism=SCRAM-SHA-512
      sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username="${jsondecode(data.aws_secretsmanager_secret_version.msk_acl_admin.secret_string).username}" password="${jsondecode(data.aws_secretsmanager_secret_version.msk_acl_admin.secret_string).password}" ;
    EOT
  }
}
```

The operator reads the Secret via `STRIMZI_KAFKA_ADMIN_CLIENT_CONFIGURATION`
regardless of which mechanism produced it.

## Why

ExternalSecrets is excellent but is not universally installed. Forcing it as a
hard prerequisite made the chart non-viable for clusters that haven't
adopted it (or that use alternative secret-sync tools).

## Test plan

- [x] `helm lint` passes
- [x] `helm template --set externalSecret.enabled=false` renders 5 namespace-scoped kinds (no ExternalSecret)
- [x] `helm template --set externalSecret.enabled=true` renders 6 namespace-scoped kinds including ExternalSecret
- [ ] Release workflow publishes 0.3.0 to spartan-stratos.github.io/helm-charts
