### PR TITLE
feat(strimzi-user-operator): add nodeSelector/tolerations/affinity (0.3.1)

### DIFF
--- a/charts/strimzi-user-operator/CHANGELOG.md
+++ b/charts/strimzi-user-operator/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this chart are documented in this file.
 
+## [0.3.1](https://github.com/spartan-stratos/helm-charts/releases/tag/strimzi-user-operator-0.3.1) (2026-05-14)
+
+### Features
+
+* `nodeSelector`, `tolerations`, `affinity` values added to the Deployment.
+  Required for clusters whose nodes carry taints (e.g. EKS Fargate adds
+  `eks.amazonaws.com/compute-type=fargate:NoSchedule` to every node — pods
+  without a matching toleration stay `Pending` with `FailedScheduling`).
+  Defaults are empty so the chart still works on untainted clusters.
+
 ## [0.3.0](https://github.com/spartan-stratos/helm-charts/releases/tag/strimzi-user-operator-0.3.0) (2026-05-14)
 
 ### Features

--- a/charts/strimzi-user-operator/Chart.yaml
+++ b/charts/strimzi-user-operator/Chart.yaml
@@ -13,5 +13,5 @@ description: |
   Manages Kafka ACL declaratively via KafkaUser CRDs. KafkaUser CRD
   instances live in the sibling `kafka-users` chart.
 type: application
-version: 0.3.0
+version: 0.3.1
 appVersion: "0.45.1"

--- a/charts/strimzi-user-operator/templates/deployment.yaml
+++ b/charts/strimzi-user-operator/templates/deployment.yaml
@@ -96,3 +96,15 @@ spec:
             timeoutSeconds: 5
       restartPolicy: Always
       terminationGracePeriodSeconds: 30
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/strimzi-user-operator/values.yaml
+++ b/charts/strimzi-user-operator/values.yaml
@@ -63,6 +63,14 @@ resources:
     cpu: 500m
     memory: 512Mi
 
+# Pod scheduling hints — empty defaults so the chart works on any cluster.
+# Set per-consumer if the target cluster has tainted nodes (e.g. EKS Fargate
+# adds `eks.amazonaws.com/compute-type=fargate:NoSchedule` to its nodes;
+# consumer must supply a matching toleration).
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
 # Reconcile cadence (ms). Strimzi default is 120000 (2 min). Keep default —
 # our ACL change frequency is low.
 fullReconciliationIntervalMs: 120000


### PR DESCRIPTION
## Summary

Adds standard Pod scheduling hints to the Deployment so consumers on tainted nodes can schedule the operator.

```yaml
# values.yaml
nodeSelector: {}
tolerations: []
affinity: {}
```

Empty defaults — chart still works as before on untainted clusters.

## Why

First reference consumer (8fleet) runs EKS Fargate. Fargate adds `eks.amazonaws.com/compute-type=fargate:NoSchedule` to every node; pods without a matching toleration fail to schedule:

```
0/9 nodes are available: 9 node(s) had untolerated taint(s)
```

The upstream Strimzi Deployment YAML for standalone UO doesn't carry tolerations, so the wrapper chart needs to expose them.

## Test plan

- [x] `helm lint` passes
- [x] `helm template` (no overrides) renders without scheduling stanza (back-compat)
- [x] `helm template --set 'tolerations[0].key=eks.amazonaws.com/compute-type'...` renders tolerations stanza
- [ ] First consumer (8fleet) supplies Fargate toleration via valuesObject; pod schedules within ~1 min