### PR TITLE
fix(strimzi-user-operator): populate placeholder CA secrets (0.3.2)

### DIFF
--- a/charts/strimzi-user-operator/CHANGELOG.md
+++ b/charts/strimzi-user-operator/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this chart are documented in this file.
 
+## [0.3.2](https://github.com/spartan-stratos/helm-charts/releases/tag/strimzi-user-operator-0.3.2) (2026-05-14)
+
+### Bug fixes
+
+* Populate the placeholder CA Secrets with a generated self-signed cert
+  (`genCA`) instead of leaving them empty. Strimzi 0.45.x's startup
+  actually parses these Secrets — `PemTrustSet.extractCerts()` throws
+  `RuntimeException: The Secret ... does not contain any fields with the
+  suffix .crt` if the Secret data is empty. The throwaway CA is never
+  trusted by anything (operator talks to MSK over public-CA TLS via
+  `STRIMZI_PUBLIC_CA=true`); it exists solely to satisfy the parser.
+
 ## [0.3.1](https://github.com/spartan-stratos/helm-charts/releases/tag/strimzi-user-operator-0.3.1) (2026-05-14)
 
 ### Features

--- a/charts/strimzi-user-operator/Chart.yaml
+++ b/charts/strimzi-user-operator/Chart.yaml
@@ -13,5 +13,5 @@ description: |
   Manages Kafka ACL declaratively via KafkaUser CRDs. KafkaUser CRD
   instances live in the sibling `kafka-users` chart.
 type: application
-version: 0.3.1
+version: 0.3.2
 appVersion: "0.45.1"

--- a/charts/strimzi-user-operator/templates/placeholder-ca-secrets.yaml
+++ b/charts/strimzi-user-operator/templates/placeholder-ca-secrets.yaml
@@ -1,12 +1,23 @@
-# Placeholder CA Secrets — workaround for Strimzi standalone User Operator
-# requiring STRIMZI_CA_CERT_NAME and STRIMZI_CA_KEY_NAME env vars even when
-# we don't manage credentials (and therefore don't need a CA).
-#
-# Upstream issue: https://github.com/strimzi/strimzi-kafka-operator/issues/8284
-# The operator startup validates that these Secrets exist; the contents are
-# never actually used because KafkaUser CRDs in this deployment use
-# authorization-only mode (no `authentication:` block, no credential
-# generation).
+{{- /*
+  Placeholder CA Secrets — workaround for Strimzi standalone User Operator
+  requiring STRIMZI_CA_CERT_NAME / STRIMZI_CA_KEY_NAME even when the
+  operator is configured for authorization-only mode (no credential
+  generation, no `authentication:` block on KafkaUser CRDs).
+
+  Upstream issue: https://github.com/strimzi/strimzi-kafka-operator/issues/8284
+
+  Strimzi 0.45.x's startup actually PARSES the placeholder secret — it
+  doesn't just check for existence. PemTrustSet.extractCerts() throws if
+  no Secret data field ends in `.crt`, and downstream code expects the
+  content to be a valid PEM X.509 cert. So we generate a throwaway
+  self-signed CA at install time and stuff it into both secrets.
+
+  The CA is regenerated on every `helm upgrade --install` since `genCA`
+  is non-deterministic — that's fine, the cert is never trusted by any
+  Kafka client (operator only talks to MSK over public-CA TLS, gated by
+  STRIMZI_PUBLIC_CA=true). It exists solely to satisfy the parser.
+*/ -}}
+{{- $ca := genCA "kafka-acl-placeholder-ca" 3650 -}}
 ---
 apiVersion: v1
 kind: Secret
@@ -17,7 +28,8 @@ metadata:
     app.kubernetes.io/name: strimzi-user-operator
     strimzi.io/kind: Kafka
 type: Opaque
-data: {}
+data:
+  ca.crt: {{ $ca.Cert | b64enc | quote }}
 ---
 apiVersion: v1
 kind: Secret
@@ -28,4 +40,5 @@ metadata:
     app.kubernetes.io/name: strimzi-user-operator
     strimzi.io/kind: Kafka
 type: Opaque
-data: {}
+data:
+  ca.key: {{ $ca.Key | b64enc | quote }}


### PR DESCRIPTION
## Summary

Operator pod 0.3.1 crashes on startup with:

```
java.lang.RuntimeException: The Secret kafka-acl/placeholder-ca-cert
does not contain any fields with the suffix .crt
  at io.strimzi.operator.common.auth.PemTrustSet.extractCerts(PemTrustSet.java:128)
```

The previous workaround (empty Secret) assumed Strimzi only checked Secret existence. Strimzi 0.45.x actually parses the content and throws if no Secret data field ends in `.crt`. Populate `ca.crt` + `ca.key` with a Helm-generated self-signed CA so the parser is satisfied.

The cert is never trusted by anything — the operator talks to MSK over public-CA TLS via `STRIMZI_PUBLIC_CA=true`. The placeholder CA exists solely so Strimzi's startup doesn't NPE.

## Test plan

- [x] `helm lint` passes
- [x] `helm template` renders ca.crt + ca.key with valid PEM content
- [ ] Operator pod 0.3.2 reaches Ready (no RuntimeException at startup)
- [ ] AdminClient initialized → reconcile loop runs against MSK