### PR TITLE
feat(schema-registry): chart for Confluent SR pointed at MSK

### DIFF
--- a/charts/schema-registry/CHANGELOG.md
+++ b/charts/schema-registry/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## 0.1.0
+
+Initial release.
+
+- `Deployment` for `confluentinc/cp-schema-registry:7.6.1`.
+- `ClusterIP` `Service` on port 8081.
+- SASL/SCRAM auth to MSK using a consumer-provided K8s `Secret` (key `jaas`).
+- Probes on `/subjects`.

--- a/charts/schema-registry/Chart.yaml
+++ b/charts/schema-registry/Chart.yaml
@@ -1,0 +1,14 @@
+apiVersion: v2
+name: schema-registry
+description: |
+  Confluent Schema Registry pointed at an external Kafka cluster
+  (e.g. AWS MSK over SASL/SCRAM). Stateless Deployment + ClusterIP
+  Service; all durable state lives in the Kafka `_schemas` topic.
+
+  The chart only ships namespace-scoped resources (Deployment, Service).
+  Namespace, SCRAM credentials Secret, and the `_schemas` topic itself
+  are the consumer's responsibility to bootstrap — typically via
+  Terraform alongside the MSK cluster.
+type: application
+version: 0.1.0
+appVersion: "7.6.1"

--- a/charts/schema-registry/README.md
+++ b/charts/schema-registry/README.md
@@ -1,0 +1,86 @@
+# schema-registry
+
+[Confluent Schema Registry](https://docs.confluent.io/platform/current/schema-registry/index.html)
+pointed at an **external AWS MSK** cluster over SASL/SCRAM. Stateless
+`Deployment` + `ClusterIP` `Service`; all durable state lives in the
+Kafka `_schemas` topic.
+
+> **Opinionated:** this chart targets one specific path — Confluent SR
+> talking to AWS MSK via SASL/SCRAM, with the SCRAM credential and the
+> `_schemas` topic provisioned out-of-band (Terraform). If you want the
+> full Confluent Platform Helm chart with ZooKeeper bundled, use
+> [cp-helm-charts](https://github.com/confluentinc/cp-helm-charts)
+> upstream.
+
+## When to use
+
+- You run AWS MSK (managed Kafka).
+- You want a thin, single-purpose SR chart you can read in one screen.
+- The `_schemas` topic + SCRAM credential are managed by Terraform.
+
+## What this chart ships
+
+All resources are **namespace-scoped** (drops in a default-deny
+`AppProject`):
+
+- `Deployment` for the SR pod (env-only config — no `ConfigMap`)
+- `ClusterIP` `Service` exposing port 8081 inside the cluster
+
+## Prerequisites (consumer-bootstrapped — NOT in this chart)
+
+These must exist before installing the chart. Provision once via the
+consumer's Terraform.
+
+| Resource | Owner |
+|---|---|
+| `Namespace` (`schema-registry` by default) | Terraform |
+| `Secret` with key `jaas` holding a single-line `org.apache.kafka.common.security.scram.ScramLoginModule required username=... password=... ;` | Terraform |
+| MSK `_schemas` topic with `cleanup.policy=compact`, `min.insync.replicas=2`, `replication.factor=3` (prod) | Terraform |
+| Kafka ACL granting the SCRAM user `Read`+`Write` on topic `_schemas` and on group prefix `schema-registry` | Strimzi User Operator via `KafkaUser` CRD |
+| EKS Fargate Profile selector on the SR namespace (if running on Fargate) | Terraform |
+
+## Required values
+
+```yaml
+env: dev                          # observability label
+
+mskBootstrapServersSaslScram: "b-1.<cluster>.<region>.amazonaws.com:9096,..."
+
+scramSecret:
+  name: schema-registry-creds     # Secret name created by Terraform
+  jaasKey: jaas                   # Secret key holding the JAAS string
+
+kafkaStore:
+  topic: _schemas                 # MUST be _schemas — SR refuses any other value
+  replicationFactor: 3            # prod: 3, dev: 1
+```
+
+## Connecting from clients
+
+In-cluster clients reach SR at:
+
+```
+http://schema-registry.<namespace>.svc.cluster.local:8081
+```
+
+There is no Ingress in this chart by design — SR has no auth and must
+stay private.
+
+## Image
+
+`confluentinc/cp-schema-registry:{{ .Chart.AppVersion }}` from Docker Hub.
+Confluent Community License (CCL) — fine for internal self-hosted use,
+no redistribution.
+
+## Operations
+
+- Pod restart rebuilds the in-memory index by replaying `_schemas`. Cold
+  start scales linearly with the topic — 1-3 s typical, much longer once
+  you have tens of thousands of schemas.
+- Multiple replicas elect a leader via Kafka. Only the leader writes; all
+  replicas serve reads. Bump `replicaCount` to 2-3 in prod.
+
+## Related
+
+- `kafka-users` chart — declare the SR SCRAM user's ACL
+- `strimzi-user-operator` chart — reconcile that ACL onto MSK

--- a/charts/schema-registry/templates/deployment.yaml
+++ b/charts/schema-registry/templates/deployment.yaml
@@ -1,0 +1,81 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: schema-registry
+  namespace: {{ .Values.namespace.name }}
+  labels:
+    app.kubernetes.io/name: schema-registry
+    app.kubernetes.io/part-of: schema-registry
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: schema-registry
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: schema-registry
+        tags.datadoghq.com/env: {{ .Values.env }}
+        tags.datadoghq.com/service: schema-registry
+    spec:
+      containers:
+        - name: schema-registry
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.listenerPort }}
+              protocol: TCP
+          env:
+            - name: SCHEMA_REGISTRY_HOST_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: SCHEMA_REGISTRY_LISTENERS
+              value: "http://0.0.0.0:{{ .Values.listenerPort }}"
+            # Confluent SR expects each broker carry its own protocol
+            # prefix: SASL_SSL://b-1...,SASL_SSL://b-2...,SASL_SSL://b-3...
+            # The chart input is the bare comma-separated MSK output, so
+            # rewrite the separators here.
+            - name: SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS
+              value: "SASL_SSL://{{ replace "," ",SASL_SSL://" .Values.mskBootstrapServersSaslScram }}"
+            - name: SCHEMA_REGISTRY_KAFKASTORE_TOPIC
+              value: {{ .Values.kafkaStore.topic | quote }}
+            - name: SCHEMA_REGISTRY_KAFKASTORE_TOPIC_REPLICATION_FACTOR
+              value: "{{ .Values.kafkaStore.replicationFactor }}"
+            - name: SCHEMA_REGISTRY_KAFKASTORE_SECURITY_PROTOCOL
+              value: SASL_SSL
+            - name: SCHEMA_REGISTRY_KAFKASTORE_SASL_MECHANISM
+              value: SCRAM-SHA-512
+            - name: SCHEMA_REGISTRY_KAFKASTORE_SASL_JAAS_CONFIG
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.scramSecret.name }}
+                  key: {{ .Values.scramSecret.jaasKey }}
+            - name: SCHEMA_REGISTRY_LEADER_ELIGIBILITY
+              value: "{{ .Values.leaderEligibility }}"
+          resources:
+            requests:
+              cpu: {{ .Values.resources.requests.cpu }}
+              memory: {{ .Values.resources.requests.memory }}
+            limits:
+              cpu: {{ .Values.resources.limits.cpu }}
+              memory: {{ .Values.resources.limits.memory }}
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/schema-registry/templates/service.yaml
+++ b/charts/schema-registry/templates/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: schema-registry
+  namespace: {{ .Values.namespace.name }}
+  labels:
+    app.kubernetes.io/name: schema-registry
+    app.kubernetes.io/part-of: schema-registry
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    app.kubernetes.io/name: schema-registry
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: {{ .Values.listenerPort }}
+      protocol: TCP

--- a/charts/schema-registry/values.yaml
+++ b/charts/schema-registry/values.yaml
@@ -1,0 +1,83 @@
+# Confluent Schema Registry — defaults. Override per env.
+# See values-dev.yaml / values-prod.yaml in the consumer ArgoCD repo
+# for env-specific bindings (MSK bootstrap, replication factor, etc.).
+
+env: ""
+
+namespace:
+  name: schema-registry
+
+image:
+  repository: confluentinc/cp-schema-registry
+  tag: "7.6.1"
+  pullPolicy: IfNotPresent
+
+replicaCount: 1
+
+# MSK SASL/SCRAM bootstrap endpoint — output from infra-terraform/live
+# (module.msk.bootstrap_brokers_sasl_scram). Per env.
+mskBootstrapServersSaslScram: ""
+
+# K8s Secret carrying the `schema-registry` SCRAM credential, created by
+# infra-terraform live/schema-registry-bootstrap.tf. Must hold a key
+# `jaas` whose value is a single-line JAAS string for SASL/SCRAM.
+scramSecret:
+  name: schema-registry-creds
+  jaasKey: jaas
+
+# `_schemas` topic settings — must match what was provisioned in MSK.
+# Replication factor of 3 in prod, 1 in dev to stay under broker count.
+# The topic is `_schemas` (literal); SR refuses to start if any other
+# value is given here.
+kafkaStore:
+  topic: _schemas
+  replicationFactor: 1
+
+# Leader election among replicas. Only one SR pod writes to `_schemas`
+# at a time; followers serve reads.
+leaderEligibility: true
+
+# Container port for the REST listener. Helm Service forwards 8081 → here.
+listenerPort: 8081
+
+service:
+  type: ClusterIP
+  port: 8081
+
+resources:
+  requests:
+    cpu: 200m
+    memory: 512Mi
+  limits:
+    cpu: 1000m
+    memory: 1Gi
+
+# Pod scheduling — empty defaults so the chart works on any cluster.
+# Consumers on EKS Fargate must supply the
+# `eks.amazonaws.com/compute-type=fargate:NoSchedule` toleration; the
+# matching Fargate Profile selector on the SR namespace is the
+# consumer's Terraform responsibility.
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+# Probes — SR's REST endpoint `/subjects` returns 200 once Kafka store
+# warmup is done. Generous initial delay covers the initial topic
+# rebuild during pod startup.
+livenessProbe:
+  httpGet:
+    path: /subjects
+    port: 8081
+  initialDelaySeconds: 60
+  periodSeconds: 30
+  timeoutSeconds: 10
+  failureThreshold: 5
+
+readinessProbe:
+  httpGet:
+    path: /subjects
+    port: 8081
+  initialDelaySeconds: 20
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 3


### PR DESCRIPTION
## Summary

Thin Helm chart wrapping \`confluentinc/cp-schema-registry:7.6.1\`. Designed to plug into an existing MSK + Strimzi-managed-ACL bootstrap (the pattern already used for kafka-users / strimzi-user-operator in this repo).

## What ships

- Stateless \`Deployment\` (durable state lives in the Kafka \`_schemas\` topic).
- \`ClusterIP\` \`Service\` on port 8081 — in-cluster only by design (SR has no auth, must stay private).
- Env-only configuration; no \`ConfigMap\`. JAAS string for SASL/SCRAM is read from a consumer-provided \`Secret\` (key \`jaas\`).
- Probes on \`/subjects\`.

## What this chart does NOT ship (consumer responsibility)

| Resource | Owner (in our setup) |
|---|---|
| \`Namespace\` | Terraform (\`live/schema-registry-bootstrap.tf\`) |
| \`Secret\` with JAAS string | Terraform (same file) |
| MSK \`_schemas\` topic | Terraform (service-fleet repo) |
| Kafka ACL for the SR SCRAM user | Strimzi User Operator (\`kafka-users\` chart entry) |
| EKS Fargate Profile selector on namespace | Terraform (\`live/eks.tf\`) |

This split keeps the chart deployable from a default-deny ArgoCD AppProject (no cluster-scoped resources).

## Tricky bits

**Per-broker protocol prefix.** Confluent SR requires \`kafkastore.bootstrap.servers\` to carry the protocol scheme on every entry: \`SASL_SSL://b-1...,SASL_SSL://b-2...,SASL_SSL://b-3...\`. The chart input is the bare comma-separated MSK output, so the deployment template rewrites separators with Helm \`replace\`. Verified by \`helm template\`.

**No leader election config needed at chart level.** SR uses Kafka group-coordinator-driven leader election out of the box; the only flag is \`SCHEMA_REGISTRY_LEADER_ELIGIBILITY\` (defaulted to true).

## Verification

- \`helm lint\` — clean.
- \`helm template\` with 3-broker input — renders \`SASL_SSL://b-1...,SASL_SSL://b-2...,SASL_SSL://b-3...\` as expected.

## Follow-up

Three PRs land after this merges + the \`gh-pages\` workflow publishes the chart:

1. \`infra-terraform\` — add \`schema-registry\` to \`fargate_namespaces\` in \`live/eks.tf\`.
2. \`infra-argocd:dev\` — \`values-schema-registry.yaml\` Application + \`schema-registry\` SCRAM user entry in \`values-kafka-users.yaml\` (Read+Write on \`_schemas\`, Read+Write on group prefix \`schema-registry\`).
3. \`infra-argocd:prod\` — same shape on prod branch (separate PR per branch model).