### PR TITLE
feat(charts): source MSK broker DNS from ConfigMap

### DIFF
--- a/charts/schema-registry/CHANGELOG.md
+++ b/charts/schema-registry/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.2.0
+
+Broker DNS now sourced from a consumer-provided K8s `ConfigMap` instead
+of a Helm value. The `mskBootstrapServersSaslScram` input is gone;
+configure `brokersConfigMap.{name,key}` instead. The ConfigMap value
+must already include the per-broker `SASL_SSL://` protocol prefix.
+
+This lets Terraform own the broker DNS and roll the SR pod on MSK
+broker changes without edits to ArgoCD values.
+
 ## 0.1.0
 
 Initial release.

--- a/charts/schema-registry/Chart.yaml
+++ b/charts/schema-registry/Chart.yaml
@@ -10,5 +10,5 @@ description: |
   are the consumer's responsibility to bootstrap — typically via
   Terraform alongside the MSK cluster.
 type: application
-version: 0.1.0
+version: 0.2.0
 appVersion: "7.6.1"

--- a/charts/schema-registry/templates/deployment.yaml
+++ b/charts/schema-registry/templates/deployment.yaml
@@ -33,12 +33,11 @@ spec:
                   fieldPath: status.podIP
             - name: SCHEMA_REGISTRY_LISTENERS
               value: "http://0.0.0.0:{{ .Values.listenerPort }}"
-            # Confluent SR expects each broker carry its own protocol
-            # prefix: SASL_SSL://b-1...,SASL_SSL://b-2...,SASL_SSL://b-3...
-            # The chart input is the bare comma-separated MSK output, so
-            # rewrite the separators here.
             - name: SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS
-              value: "SASL_SSL://{{ replace "," ",SASL_SSL://" .Values.mskBootstrapServersSaslScram }}"
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ .Values.brokersConfigMap.name }}
+                  key: {{ .Values.brokersConfigMap.key }}
             - name: SCHEMA_REGISTRY_KAFKASTORE_TOPIC
               value: {{ .Values.kafkaStore.topic | quote }}
             - name: SCHEMA_REGISTRY_KAFKASTORE_TOPIC_REPLICATION_FACTOR

--- a/charts/schema-registry/values.yaml
+++ b/charts/schema-registry/values.yaml
@@ -1,6 +1,4 @@
 # Confluent Schema Registry — defaults. Override per env.
-# See values-dev.yaml / values-prod.yaml in the consumer ArgoCD repo
-# for env-specific bindings (MSK bootstrap, replication factor, etc.).
 
 env: ""
 
@@ -14,9 +12,16 @@ image:
 
 replicaCount: 1
 
-# MSK SASL/SCRAM bootstrap endpoint — output from infra-terraform/live
-# (module.msk.bootstrap_brokers_sasl_scram). Per env.
-mskBootstrapServersSaslScram: ""
+# K8s ConfigMap carrying the MSK SASL/SCRAM bootstrap servers, written
+# by the consumer's Terraform from `module.msk.bootstrap_brokers_sasl_scram`.
+# Value at `key` must already include the per-broker `SASL_SSL://` prefix
+# (Confluent SR requires each entry to carry its own protocol scheme).
+# Sourcing this from K8s means a broker scale-out flows through
+# `terraform apply` -> ConfigMap update -> pod restart on next reconcile,
+# with no edits to ArgoCD values.
+brokersConfigMap:
+  name: schema-registry-broker-config
+  key: SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS
 
 # K8s Secret carrying the `schema-registry` SCRAM credential, created by
 # infra-terraform live/schema-registry-bootstrap.tf. Must hold a key
@@ -26,18 +31,13 @@ scramSecret:
   jaasKey: jaas
 
 # `_schemas` topic settings — must match what was provisioned in MSK.
-# Replication factor of 3 in prod, 1 in dev to stay under broker count.
-# The topic is `_schemas` (literal); SR refuses to start if any other
-# value is given here.
+# The topic name is fixed at `_schemas`; SR refuses any other value.
 kafkaStore:
   topic: _schemas
   replicationFactor: 1
 
-# Leader election among replicas. Only one SR pod writes to `_schemas`
-# at a time; followers serve reads.
 leaderEligibility: true
 
-# Container port for the REST listener. Helm Service forwards 8081 → here.
 listenerPort: 8081
 
 service:
@@ -52,18 +52,10 @@ resources:
     cpu: 1000m
     memory: 1Gi
 
-# Pod scheduling — empty defaults so the chart works on any cluster.
-# Consumers on EKS Fargate must supply the
-# `eks.amazonaws.com/compute-type=fargate:NoSchedule` toleration; the
-# matching Fargate Profile selector on the SR namespace is the
-# consumer's Terraform responsibility.
 nodeSelector: {}
 tolerations: []
 affinity: {}
 
-# Probes — SR's REST endpoint `/subjects` returns 200 once Kafka store
-# warmup is done. Generous initial delay covers the initial topic
-# rebuild during pod startup.
 livenessProbe:
   httpGet:
     path: /subjects

--- a/charts/strimzi-user-operator/CHANGELOG.md
+++ b/charts/strimzi-user-operator/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this chart are documented in this file.
 
+## [0.4.0](https://github.com/spartan-stratos/helm-charts/releases/tag/strimzi-user-operator-0.4.0) (2026-05-15)
+
+### Features
+
+* Optional `brokersConfigMap` value sources the MSK bootstrap broker
+  endpoint from a consumer-provided K8s `ConfigMap` (via
+  `valueFrom.configMapKeyRef`) instead of the Helm value
+  `mskBootstrapServersSaslScram`. Enabling lets Terraform own the
+  broker DNS and roll the operator pod on MSK broker changes without
+  edits to ArgoCD values.
+
+  Backwards-compatible: `brokersConfigMap.enabled` defaults to `false`,
+  so existing consumers continue to use `mskBootstrapServersSaslScram`.
+
 ## [0.3.4](https://github.com/spartan-stratos/helm-charts/releases/tag/strimzi-user-operator-0.3.4) (2026-05-14)
 
 ### Bug fixes

--- a/charts/strimzi-user-operator/Chart.yaml
+++ b/charts/strimzi-user-operator/Chart.yaml
@@ -13,5 +13,5 @@ description: |
   Manages Kafka ACL declaratively via KafkaUser CRDs. KafkaUser CRD
   instances live in the sibling `kafka-users` chart.
 type: application
-version: 0.3.4
+version: 0.4.0
 appVersion: "0.45.1"

--- a/charts/strimzi-user-operator/templates/deployment.yaml
+++ b/charts/strimzi-user-operator/templates/deployment.yaml
@@ -35,7 +35,14 @@ spec:
 
             # ── Connect to MSK ───────────────────────────────────────────
             - name: STRIMZI_KAFKA_BOOTSTRAP_SERVERS
+              {{- if .Values.brokersConfigMap.enabled }}
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ .Values.brokersConfigMap.name }}
+                  key: {{ .Values.brokersConfigMap.key }}
+              {{- else }}
               value: {{ .Values.mskBootstrapServersSaslScram | quote }}
+              {{- end }}
             # SASL/SCRAM config block read from the ExternalSecret-synced
             # K8s Secret. Strimzi accepts free-form admin client properties.
             - name: STRIMZI_KAFKA_ADMIN_CLIENT_CONFIGURATION

--- a/charts/strimzi-user-operator/values.yaml
+++ b/charts/strimzi-user-operator/values.yaml
@@ -20,10 +20,24 @@ image:
   tag: "0.45.1"
   pullPolicy: IfNotPresent
 
-# MSK SASL/SCRAM bootstrap endpoint — output from infra-terraform/live.
-# Set per env file. Example shape:
-#   "b-1.<cluster>.kafka.us-west-2.amazonaws.com:9096,b-2.<cluster>...,b-3..."
+# MSK SASL/SCRAM bootstrap endpoint — legacy hardcoded value. Used only
+# when `brokersConfigMap.enabled` is false. Deprecated; prefer the
+# ConfigMap-sourced path below.
 mskBootstrapServersSaslScram: ""
+
+# Source the broker endpoint from a consumer-provided K8s ConfigMap
+# instead of the Helm value above. The ConfigMap key holds the bare
+# comma-separated broker list (no protocol prefix — Strimzi UO accepts
+# the bare form). Sourcing from K8s lets Terraform own the broker DNS
+# and roll the operator pod on MSK broker changes without edits to
+# ArgoCD values.
+#
+# Defaults disabled so existing consumers that pass
+# `mskBootstrapServersSaslScram` continue to work.
+brokersConfigMap:
+  enabled: false
+  name: msk-cluster-info
+  key: STRIMZI_KAFKA_BOOTSTRAP_SERVERS
 
 # AWS Secrets Manager secret name for the msk-acl-admin SCRAM credential.
 # Created by infra-terraform `module.msk_acl_admin`. ExternalSecrets syncs


### PR DESCRIPTION
Removes `mskBootstrapServersSaslScram` from helm values in favour of a K8s ConfigMap reference. Consumer Terraform owns the broker DNS; broker changes flow through `terraform apply` -> ConfigMap update -> pod restart with no ArgoCD YAML edits.

- `schema-registry` 0.1.0 -> 0.2.0 (breaking — chart not yet deployed anywhere)
- `strimzi-user-operator` 0.3.4 -> 0.4.0 (backwards-compatible toggle via `brokersConfigMap.enabled`)

Follow-up PRs (infra-terraform + infra-argocd) write the ConfigMaps and enable the new path.