### PR TITLE
fix(schema-registry): disable service-link env injection (0.2.1)

### DIFF
--- a/charts/schema-registry/CHANGELOG.md
+++ b/charts/schema-registry/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.2.1
+
+Set `pod.spec.enableServiceLinks: false`. K8s otherwise auto-injects an
+env var `SCHEMA_REGISTRY_PORT` derived from the chart's own Service.
+Confluent's `/etc/confluent/docker/configure` interprets that name as
+the legacy listener-port setting and exits 1 on startup.
+
 ## 0.2.0
 
 Broker DNS now sourced from a consumer-provided K8s `ConfigMap` instead

--- a/charts/schema-registry/Chart.yaml
+++ b/charts/schema-registry/Chart.yaml
@@ -10,5 +10,5 @@ description: |
   are the consumer's responsibility to bootstrap — typically via
   Terraform alongside the MSK cluster.
 type: application
-version: 0.2.0
+version: 0.2.1
 appVersion: "7.6.1"

--- a/charts/schema-registry/templates/deployment.yaml
+++ b/charts/schema-registry/templates/deployment.yaml
@@ -18,6 +18,12 @@ spec:
         tags.datadoghq.com/env: {{ .Values.env }}
         tags.datadoghq.com/service: schema-registry
     spec:
+      # K8s auto-injects env vars for every Service in the namespace,
+      # naming them <UPPERCASED_SERVICE>_PORT etc. Our `schema-registry`
+      # Service collides with the env var name `SCHEMA_REGISTRY_PORT`
+      # that Confluent's docker `configure` script treats as the legacy
+      # listener-port setting and exits 1 if set. Disable the auto-inject.
+      enableServiceLinks: false
       containers:
         - name: schema-registry
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"


### PR DESCRIPTION
SR pod crashes on startup because K8s auto-injects `SCHEMA_REGISTRY_PORT` from the chart's own Service, and Confluent's configure script reads that name as the legacy listener-port setting and exits 1.

Setting `pod.spec.enableServiceLinks: false` stops the injection.

Bumps chart 0.2.0 -> 0.2.1.