### PR TITLE
feat(spartan): add checksum/configmap + checksum/secret annotations (0.3.0)

### DIFF
--- a/charts/spartan/Chart.yaml
+++ b/charts/spartan/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.3.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.2.0
+appVersion: 0.3.0

--- a/charts/spartan/templates/deployment.yaml
+++ b/charts/spartan/templates/deployment.yaml
@@ -21,10 +21,12 @@ spec:
       {{- include "spartan.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
+        checksum/configmap: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
       labels:
         {{- include "spartan.selectorLabels" . | nindent 8 }}
         tier: "application"

--- a/charts/spartan/tests/deployment_test.yaml
+++ b/charts/spartan/tests/deployment_test.yaml
@@ -2,9 +2,12 @@ suite: "Deployment template tests"
 
 templates:
   - "templates/deployment.yaml"
+  - "templates/configmap.yaml"
+  - "templates/secret.yaml"
 
 tests:
   - it: "renders global podLabels on the main deployment pod template"
+    template: "templates/deployment.yaml"
     set:
       podLabels:
         team: platform
@@ -18,3 +21,38 @@ tests:
       - equal:
           path: spec.template.metadata.labels.environment
           value: production
+
+  - it: "emits checksum/configmap + checksum/secret on pod template"
+    template: "templates/deployment.yaml"
+    asserts:
+      - exists:
+          path: spec.template.metadata.annotations["checksum/configmap"]
+      - exists:
+          path: spec.template.metadata.annotations["checksum/secret"]
+
+  - it: "checksum/configmap hash changes when configMap data changes"
+    template: "templates/deployment.yaml"
+    set:
+      configMap:
+        asEnv:
+          enabled: true
+          data:
+            FOO: "v1"
+    asserts:
+      - notEqual:
+          path: spec.template.metadata.annotations["checksum/configmap"]
+          value: "316deeb28892b1cdebfe5c12c2cd620b5b8f29289c1ffe3d4f5fc1b2e6a4ea7d"
+
+  - it: "merges chart checksum annotations with user-supplied podAnnotations"
+    template: "templates/deployment.yaml"
+    set:
+      podAnnotations:
+        custom.io/foo: bar
+    asserts:
+      - exists:
+          path: spec.template.metadata.annotations["checksum/configmap"]
+      - exists:
+          path: spec.template.metadata.annotations["checksum/secret"]
+      - equal:
+          path: spec.template.metadata.annotations["custom.io/foo"]
+          value: bar


### PR DESCRIPTION
## Summary

Bind pod lifecycle to mounted ConfigMap/Secret content via the standard Helm idiom.

Without this annotation, Deployment pods continue using the stale in-memory values from boot when the chart's ConfigMap or Secret content is rewritten by `helm upgrade`. Operators must manually `kubectl rollout restart` to pick up the change — easy to forget, hard to detect.

With the checksum annotations, any content change in `templates/configmap.yaml` or `templates/secret.yaml` flips the annotation hash, which changes the pod template spec, which triggers a rolling update through normal Kubernetes Deployment reconciliation.

## Changes

- ``charts/spartan/templates/deployment.yaml`` — add ``checksum/configmap`` + ``checksum/secret`` annotations on the pod template, merged with any user-supplied ``podAnnotations``
- ``charts/spartan/tests/deployment_test.yaml`` — 3 new helm-unittest cases: both annotations exist, hash mutates on configMap change, coexists with custom podAnnotations
- ``charts/spartan/Chart.yaml`` — version + appVersion 0.2.0 → 0.3.0

## Test plan

- [x] ``helm lint`` clean
- [x] ``helm template`` renders both annotation keys with non-empty SHA256 values
- [x] ``helm unittest`` deployment suite — 4/4 pass (1 existing + 3 new)
- [ ] CI ``helm-check`` action against default + ``test/values.yaml`` (will run on this PR)