### PR TITLE
feat(spartan): checksum annotations on worker pod template

### DIFF
--- a/charts/spartan/CHANGELOG.md
+++ b/charts/spartan/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.0](https://github.com/spartan-stratos/helm-charts/releases/tag/spartan-0.4.0) (2026-05-19)
+
+### Features
+
+* Add `checksum/configmap` and `checksum/secret` pod-template annotations to worker Deployments
+  * `deployment.yaml` already emitted these in 0.3.0 for the main Deployment; this extends parity to the worker templates in `_worker.tpl`
+  * Workers now roll automatically when the chart-rendered ConfigMap or Secret content changes (env-var rotation, broker DNS change after MSK cluster recreate, SCRAM credential rotation, etc.)
+  * Eliminates the manual `kubectl rollout restart` step that was previously required after Helm value changes that flow into the chart's own ConfigMap/Secret
+
 ## [0.2.0](https://github.com/spartan-stratos/helm-charts/releases/tag/spartan-0.2.0) (2026-05-06)
 
 ### Features

--- a/charts/spartan/Chart.yaml
+++ b/charts/spartan/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.4.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.3.0
+appVersion: 0.4.0

--- a/charts/spartan/templates/_worker.tpl
+++ b/charts/spartan/templates/_worker.tpl
@@ -14,17 +14,18 @@ spec:
       tier: "worker"
   template:
     metadata:
-      {{- if .worker.podAnnotations }}
-      {{- with .worker.podAnnotations }}
       annotations:
-          {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- else }}
-      {{- with .Values.podAnnotations }}
-      annotations:
+        checksum/configmap: {{ include (print $.Template.BasePath "/configmap.yaml") $ | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") $ | sha256sum }}
+        {{- if .worker.podAnnotations }}
+        {{- with .worker.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- end }}
+        {{- end }}
+        {{- else }}
+        {{- with $.Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- end }}
       labels:
         {{- include "spartan.workerLabels" $ | nindent 8 }}
         tier: "worker"

--- a/charts/spartan/templates/worker.yaml
+++ b/charts/spartan/templates/worker.yaml
@@ -1,5 +1,5 @@
 {{- range $index, $worker := (.Values.workers) }}
-  {{- include "spartan.worker" (dict "worker" $worker "Values" $.Values "Chart" $.Chart "Release" $.Release) }}
+  {{- include "spartan.worker" (dict "worker" $worker "Values" $.Values "Chart" $.Chart "Release" $.Release "Template" $.Template) }}
   {{- if lt $index (sub (len $.Values.workers) 1) }}
 ---
   {{- end }}


### PR DESCRIPTION
## Summary

Extends the chart-rendered \`checksum/configmap\` + \`checksum/secret\` pod-template annotations to the worker Deployments (currently only on the main Deployment since 0.3.0). Workers now restart automatically whenever the chart's ConfigMap or Secret content changes, eliminating the manual \`kubectl rollout restart\` step that was previously required for any config rotation reaching workers.

## Motivation

\`deployment.yaml\` got these annotations in 0.3.0, so the main app pod rolls automatically when the rendered ConfigMap/Secret hashes change. \`_worker.tpl\` was overlooked — worker Deployments had no such annotation, so a Helm value change that flowed into the chart's own ConfigMap/Secret silently left the worker pods running with stale env until an operator restarted them by hand.

Hit this gap on an MSK cluster recreate this week: the broker DNS in \`KAFKA_BOOTSTRAP_SERVERS\` changed, the chart re-rendered the ConfigMap correctly, but every worker Deployment kept the previous broker DNS in memory and stayed broken until manual rollout. Same risk applies to SCRAM credential rotation, env-var refreshes, and any future operational change that touches the chart-rendered config.

## Changes

- \`templates/_worker.tpl\`: pod template always emits \`checksum/configmap\` and \`checksum/secret\` annotations; \`worker.podAnnotations\` / global \`podAnnotations\` are merged on top. Annotation indentation aligned to 8 spaces under \`template.metadata\`.
- \`templates/worker.yaml\`: the caller passes \`Template\` into the dict context handed to \`spartan.worker\`. Without this, \`\$.Template.BasePath\` is nil inside the include and the chart fails to render.
- \`Chart.yaml\`: bumps \`version\` and \`appVersion\` to \`0.4.0\` (matches the main Deployment's parity step that landed in 0.3.0).
- \`CHANGELOG.md\`: adds \`0.4.0\` entry.

## Verification

\`helm lint charts/spartan/\` — passes.

\`helm template\` smoke test with both a main app and a worker confirms both pod templates carry the annotations with matching hashes:

\`\`\`
helm template smoke-test charts/spartan/ \\
  --set 'workers[0].name=test-worker' \\
  --set 'workers[0].image.repository=nginx' \\
  --set 'workers[0].image.tag=latest' \\
  --set 'image.repository=nginx' \\
  --set 'image.tag=latest'

# main Deployment annotations:
#   checksum/configmap: 316deeb28892b1cdebfe5c12c2cd620b5b8f29289c1ffe3d4f5fc1b2e6a4ea7d
#   checksum/secret:    316deeb28892b1cdebfe5c12c2cd620b5b8f29289c1ffe3d4f5fc1b2e6a4ea7d
# worker Deployment annotations:
#   checksum/configmap: 316deeb28892b1cdebfe5c12c2cd620b5b8f29289c1ffe3d4f5fc1b2e6a4ea7d
#   checksum/secret:    316deeb28892b1cdebfe5c12c2cd620b5b8f29289c1ffe3d4f5fc1b2e6a4ea7d
\`\`\`

## Compatibility

Non-breaking. Charts that don't define workers (only main app) render identically. Charts with workers gain the annotations — first deploy after upgrade will roll all worker pods once (because the new annotations are themselves a pod-template change), which is the intended behaviour.

## Downstream impact

8Fleet-LA/service-fleet (api + worker-consumer + worker-dispatch + worker-ingestion + worker-notification + worker-onboarding) is the primary consumer and will pick this up by bumping the chart \`targetRevision\` to \`0.4.0\` in its ArgoCD application values.