### PR TITLE
feat(spartan): pluggable hook log collector

### DIFF
--- a/charts/spartan/CHANGELOG.md
+++ b/charts/spartan/CHANGELOG.md
@@ -10,6 +10,9 @@ All notable changes to this project will be documented in this file.
   * `logCollector.sidecarName` (default `datadog-agent`), `logCollector.readyCommand` (default the Datadog APM `:8126` wait), `logCollector.stopCommand` (default `sleep 10 && pkill agent`)
   * Lets a lightweight sidecar (e.g. Fluent Bit) collect the migration log instead of the full Datadog Agent image - smaller pull, faster hook start on nodes without an image cache (notably EKS Fargate)
   * Fully backward compatible: with no `logCollector` set the rendered hook Job is byte-identical to 0.4.0 (Datadog Agent readiness wait + `DD_*` env + `pkill agent` shutdown unchanged)
+* Add `sidecars[].skipDeployment` (default false) to attach a sidecar to hook Jobs only, never the Deployment
+  * Lets a hook-scoped log collector run on the migration Job while the long-running pod keeps its own sidecar set (e.g. the Datadog Agent for APM) unchanged
+  * Default false renders the Deployment byte-identically to 0.4.0
 
 ## [0.4.0](https://github.com/spartan-stratos/helm-charts/releases/tag/spartan-0.4.0) (2026-05-19)
 

--- a/charts/spartan/CHANGELOG.md
+++ b/charts/spartan/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.5.0](https://github.com/spartan-stratos/helm-charts/releases/tag/spartan-0.5.0) (2026-07-07)
+
+### Features
+
+* Make the hook log collector pluggable via an optional per-hook `logCollector` block
+  * `logCollector.sidecarName` (default `datadog-agent`), `logCollector.readyCommand` (default the Datadog APM `:8126` wait), `logCollector.stopCommand` (default `sleep 10 && pkill agent`)
+  * Lets a lightweight sidecar (e.g. Fluent Bit) collect the migration log instead of the full Datadog Agent image - smaller pull, faster hook start on nodes without an image cache (notably EKS Fargate)
+  * Fully backward compatible: with no `logCollector` set the rendered hook Job is byte-identical to 0.4.0 (Datadog Agent readiness wait + `DD_*` env + `pkill agent` shutdown unchanged)
+
 ## [0.4.0](https://github.com/spartan-stratos/helm-charts/releases/tag/spartan-0.4.0) (2026-05-19)
 
 ### Features

--- a/charts/spartan/Chart.yaml
+++ b/charts/spartan/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.0
+version: 0.5.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/spartan/templates/_hook.tpl
+++ b/charts/spartan/templates/_hook.tpl
@@ -1,10 +1,10 @@
 {{ define "spartan.hook" }}
 {{- $lc := .hook.logCollector | default dict }}
 {{- $lcName := $lc.sidecarName | default "datadog-agent" }}
-{{- if and .hook.collectLog $lc.sidecarName }}
+{{- if and .hook.collectLog .hook.logCollector }}
 {{- $sidecarNames := list }}
 {{- range .Values.sidecars }}{{- $sidecarNames = append $sidecarNames .name }}{{- end }}
-{{- if not (has $lc.sidecarName $sidecarNames) }}{{ fail (printf "spartan: hook %q logCollector.sidecarName=%q does not match any configured sidecar (sidecars[].name: %v)" .hook.name $lcName $sidecarNames) }}{{- end }}
+{{- if not (has $lcName $sidecarNames) }}{{ fail (printf "spartan: hook %q log collector %q (logCollector.sidecarName, default \"datadog-agent\") does not match any configured sidecar (sidecars[].name: %v)" .hook.name $lcName $sidecarNames) }}{{- end }}
 {{- if ne $lcName "datadog-agent" }}
 {{- if not $lc.readyCommand }}{{ fail (printf "spartan: hook %q sets logCollector.sidecarName=%q but no logCollector.readyCommand; a non-datadog-agent collector would hang on the default :8126 wait" .hook.name $lcName) }}{{- end }}
 {{- if not $lc.stopCommand }}{{ fail (printf "spartan: hook %q sets logCollector.sidecarName=%q but no logCollector.stopCommand; the default 'pkill agent' would never stop the collector and the Job would hang" .hook.name $lcName) }}{{- end }}

--- a/charts/spartan/templates/_hook.tpl
+++ b/charts/spartan/templates/_hook.tpl
@@ -1,6 +1,10 @@
 {{ define "spartan.hook" }}
 {{- $lc := .hook.logCollector | default dict }}
 {{- $lcName := $lc.sidecarName | default "datadog-agent" }}
+{{- if and $lc.sidecarName (ne $lcName "datadog-agent") }}
+{{- if not $lc.readyCommand }}{{ fail (printf "spartan: hook %q sets logCollector.sidecarName=%q but no logCollector.readyCommand; a non-datadog-agent collector would hang on the default :8126 wait" .hook.name $lcName) }}{{- end }}
+{{- if not $lc.stopCommand }}{{ fail (printf "spartan: hook %q sets logCollector.sidecarName=%q but no logCollector.stopCommand; the default 'pkill agent' would never stop the collector and the Job would hang" .hook.name $lcName) }}{{- end }}
+{{- end }}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/charts/spartan/templates/_hook.tpl
+++ b/charts/spartan/templates/_hook.tpl
@@ -1,4 +1,6 @@
 {{ define "spartan.hook" }}
+{{- $lc := .hook.logCollector | default dict }}
+{{- $lcName := $lc.sidecarName | default "datadog-agent" }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -42,7 +44,7 @@ spec:
       securityContext:
           {{- toYaml .Values.podSecurityContext | nindent 8 }}
       restartPolicy: {{ .hook.restartPolicy | default "Never" }}
-      {{- if and (.Values.datadog.enabled) (.hook.collectLog) }}
+      {{- if and (.hook.collectLog) (or .Values.datadog.enabled .hook.logCollector) }}
       shareProcessNamespace: true
       {{- end }}
       containers:
@@ -59,10 +61,16 @@ spec:
             - {{ default "/bin/sh" .hook.shell }}
             - -c
             - |
-            {{- if and (.Values.datadog.enabled) (.hook.collectLog) }}
+            {{- if and (.hook.collectLog) (or .Values.datadog.enabled .hook.logCollector) }}
+            {{- if $lc.readyCommand }}
+              trap '{{ $lc.stopCommand | default "sleep 10 && pkill agent" }}' EXIT
+              set -o pipefail
+              {{ $lc.readyCommand }}
+            {{- else }}
               trap 'sleep 10 && pkill agent' EXIT
               set -o pipefail
               if [ ! `which curl` ]; then sleep 300; else while ! curl -Ns localhost:8126; do sleep 1 && echo "Waiting for datadog agent to start...."; done; fi
+            {{- end }}
             {{- end }}
             {{- range .hook.commands }}
               {{ . }}
@@ -87,7 +95,7 @@ spec:
                 name: {{ .Values.configMap.externalConfigMapEnv.name }}
               {{- end }}
           env:
-          {{- if and (.Values.datadog.enabled) (.hook.collectLog) }}
+          {{- if and (.hook.collectLog) (or .Values.datadog.enabled .hook.logCollector) (eq $lcName "datadog-agent") }}
             - name: DD_KUBERNETES_KUBELET_NODENAME
               valueFrom:
                 fieldRef:
@@ -140,7 +148,7 @@ spec:
           {{- end }}
         {{- $hook := .hook }}
         {{- range $sidecar := .Values.sidecars }}
-          {{- if and (eq $sidecar.name "datadog-agent") ($hook.collectLog) }}
+          {{- if and (eq $sidecar.name $lcName) ($hook.collectLog) }}
             {{ include "sidecar.template" (dict "sidecar" $sidecar "Values" $.Values "Chart" $.Chart "Release" $.Release) | indent 8 }}
           {{- end }}
         {{- end }}

--- a/charts/spartan/templates/_hook.tpl
+++ b/charts/spartan/templates/_hook.tpl
@@ -148,7 +148,7 @@ spec:
               mountPath: {{ .Values.configMap.externalConfigMapFile.mountPath | quote }}
             {{- end }}
             {{- range .Values.sidecars }}
-            {{- if .sharedVolume }}
+            {{- if and .sharedVolume (eq .name $lcName) }}
             - name: sidecar-volume
               readOnly: false
               mountPath: {{ .sharedVolume.mountPath }}

--- a/charts/spartan/templates/_hook.tpl
+++ b/charts/spartan/templates/_hook.tpl
@@ -1,9 +1,14 @@
 {{ define "spartan.hook" }}
 {{- $lc := .hook.logCollector | default dict }}
 {{- $lcName := $lc.sidecarName | default "datadog-agent" }}
-{{- if and $lc.sidecarName (ne $lcName "datadog-agent") }}
+{{- if and .hook.collectLog $lc.sidecarName }}
+{{- $sidecarNames := list }}
+{{- range .Values.sidecars }}{{- $sidecarNames = append $sidecarNames .name }}{{- end }}
+{{- if not (has $lc.sidecarName $sidecarNames) }}{{ fail (printf "spartan: hook %q logCollector.sidecarName=%q does not match any configured sidecar (sidecars[].name: %v)" .hook.name $lcName $sidecarNames) }}{{- end }}
+{{- if ne $lcName "datadog-agent" }}
 {{- if not $lc.readyCommand }}{{ fail (printf "spartan: hook %q sets logCollector.sidecarName=%q but no logCollector.readyCommand; a non-datadog-agent collector would hang on the default :8126 wait" .hook.name $lcName) }}{{- end }}
 {{- if not $lc.stopCommand }}{{ fail (printf "spartan: hook %q sets logCollector.sidecarName=%q but no logCollector.stopCommand; the default 'pkill agent' would never stop the collector and the Job would hang" .hook.name $lcName) }}{{- end }}
+{{- end }}
 {{- end }}
 apiVersion: batch/v1
 kind: Job
@@ -71,7 +76,7 @@ spec:
               set -o pipefail
               {{ $lc.readyCommand }}
             {{- else }}
-              trap 'sleep 10 && pkill agent' EXIT
+              trap '{{ $lc.stopCommand | default "sleep 10 && pkill agent" }}' EXIT
               set -o pipefail
               if [ ! `which curl` ]; then sleep 300; else while ! curl -Ns localhost:8126; do sleep 1 && echo "Waiting for datadog agent to start...."; done; fi
             {{- end }}

--- a/charts/spartan/templates/deployment.yaml
+++ b/charts/spartan/templates/deployment.yaml
@@ -143,7 +143,7 @@ spec:
               mountPath: {{ .Values.configMap.externalConfigMapFile.mountPath | quote }}
           {{- end }}
           {{- range .Values.sidecars }}
-          {{- if .sharedVolume }}
+          {{- if and .sharedVolume (not .skipDeployment) }}
             - name: sidecar-volume
               readOnly: false
               mountPath: {{ .sharedVolume.mountPath }}
@@ -159,7 +159,9 @@ spec:
               mountPath: {{ .mountPath }}
           {{- end }}
         {{- range $sidecar := .Values.sidecars }}
+        {{- if not $sidecar.skipDeployment }}
         {{ include "sidecar.template" (dict "sidecar" $sidecar "Values" $.Values "Chart" $.Chart "Release" $.Release) | indent 8 }}
+        {{- end }}
         {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/spartan/tests/deployment_test.yaml
+++ b/charts/spartan/tests/deployment_test.yaml
@@ -56,3 +56,33 @@ tests:
       - equal:
           path: spec.template.metadata.annotations["custom.io/foo"]
           value: bar
+
+  - it: "skipDeployment sidecar is not attached to the Deployment"
+    template: "templates/deployment.yaml"
+    set:
+      sidecars:
+        - name: datadog-agent
+          image: datadog/agent
+          sharedVolume:
+            mountPath: /var/log/application/
+        - name: log-collector
+          image: fluent/fluent-bit:3.1.9
+          skipDeployment: true
+          sharedVolume:
+            mountPath: /var/log/application/
+    asserts:
+      # main container + datadog-agent only; log-collector is hook-only
+      - lengthEqual:
+          path: spec.template.spec.containers
+          count: 2
+      - equal:
+          path: spec.template.spec.containers[1].name
+          value: datadog-agent
+      # the skipDeployment sidecar's subPath mount is absent from the main container
+      - notContains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: sidecar-volume
+            readOnly: false
+            mountPath: /var/log/application/
+            subPath: log-collector

--- a/charts/spartan/tests/hook_test.yaml
+++ b/charts/spartan/tests/hook_test.yaml
@@ -117,3 +117,58 @@ tests:
       - equal:
           path: spec.template.metadata.labels.environment
           value: production
+
+  - it: "uses a custom logCollector sidecar instead of the datadog agent"
+    set:
+      datadog:
+        enabled: false
+      sidecars:
+        - name: log-collector
+          image: fluent/fluent-bit:3.1.9
+          sharedVolume:
+            mountPath: /var/log/application/
+      hooks:
+        - name: migration
+          hookTypes: pre-install,pre-upgrade
+          shell: /bin/sh
+          commands:
+            - flyway migrate
+          resources: {}
+          customImage:
+            enabled: true
+            image: migration-image:test
+          restartPolicy: Never
+          backoffLimit: 0
+          collectLog: true
+          logCollector:
+            sidecarName: log-collector
+            readyCommand: "test -f /var/log/application/app.log"
+            stopCommand: "pkill fluent-bit"
+    asserts:
+      - isKind:
+          of: Job
+      # process namespace still shared so the trap can stop the collector
+      - equal:
+          path: spec.template.spec.shareProcessNamespace
+          value: true
+      # new collector's shutdown + readiness wiring is rendered
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: "pkill fluent-bit"
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: "test -f /var/log/application/app.log"
+      # legacy datadog-agent wiring is gone
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: "pkill agent"
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: "localhost:8126"
+      # no datadog env injected for a non-agent collector (no extraEnvs set → env is empty)
+      - isNullOrEmpty:
+          path: spec.template.spec.containers[0].env
+      # the configured sidecar is attached to the hook pod
+      - equal:
+          path: spec.template.spec.containers[1].name
+          value: log-collector

--- a/charts/spartan/tests/hook_test.yaml
+++ b/charts/spartan/tests/hook_test.yaml
@@ -172,3 +172,29 @@ tests:
       - equal:
           path: spec.template.spec.containers[1].name
           value: log-collector
+
+  - it: "fails fast when a non-datadog collector omits readyCommand"
+    set:
+      datadog:
+        enabled: false
+      sidecars:
+        - name: log-collector
+          image: fluent/fluent-bit:3.1.9
+      hooks:
+        - name: migration
+          hookTypes: pre-install
+          shell: /bin/sh
+          commands:
+            - flyway migrate
+          resources: {}
+          customImage:
+            enabled: true
+            image: migration-image:test
+          restartPolicy: Never
+          backoffLimit: 0
+          collectLog: true
+          logCollector:
+            sidecarName: log-collector
+    asserts:
+      - failedTemplate:
+          errorPattern: "logCollector.readyCommand"

--- a/charts/spartan/tests/hook_test.yaml
+++ b/charts/spartan/tests/hook_test.yaml
@@ -253,3 +253,31 @@ tests:
     asserts:
       - failedTemplate:
           errorPattern: "does not match any configured sidecar"
+
+  - it: "fails fast when logCollector omits sidecarName and no datadog-agent sidecar exists"
+    set:
+      datadog:
+        enabled: false
+      sidecars:
+        - name: metrics
+          image: some/metrics
+      hooks:
+        - name: migration
+          hookTypes: pre-install
+          shell: /bin/sh
+          commands:
+            - flyway migrate
+          resources: {}
+          customImage:
+            enabled: true
+            image: migration-image:test
+          restartPolicy: Never
+          backoffLimit: 0
+          collectLog: true
+          # logCollector present (overriding only stopCommand) but no sidecarName ->
+          # resolves to the default "datadog-agent", which is not in sidecars -> fail
+          logCollector:
+            stopCommand: "sleep 5 && pkill agent"
+    asserts:
+      - failedTemplate:
+          errorPattern: "does not match any configured sidecar"

--- a/charts/spartan/tests/hook_test.yaml
+++ b/charts/spartan/tests/hook_test.yaml
@@ -198,3 +198,58 @@ tests:
     asserts:
       - failedTemplate:
           errorPattern: "logCollector.readyCommand"
+
+  - it: "fails fast when a non-datadog collector omits stopCommand"
+    set:
+      datadog:
+        enabled: false
+      sidecars:
+        - name: log-collector
+          image: fluent/fluent-bit:3.1.9
+      hooks:
+        - name: migration
+          hookTypes: pre-install
+          shell: /bin/sh
+          commands:
+            - flyway migrate
+          resources: {}
+          customImage:
+            enabled: true
+            image: migration-image:test
+          restartPolicy: Never
+          backoffLimit: 0
+          collectLog: true
+          logCollector:
+            sidecarName: log-collector
+            readyCommand: "test -f /x"
+    asserts:
+      - failedTemplate:
+          errorPattern: "logCollector.stopCommand"
+
+  - it: "fails fast when logCollector.sidecarName matches no configured sidecar"
+    set:
+      datadog:
+        enabled: false
+      sidecars:
+        - name: log-collector
+          image: fluent/fluent-bit:3.1.9
+      hooks:
+        - name: migration
+          hookTypes: pre-install
+          shell: /bin/sh
+          commands:
+            - flyway migrate
+          resources: {}
+          customImage:
+            enabled: true
+            image: migration-image:test
+          restartPolicy: Never
+          backoffLimit: 0
+          collectLog: true
+          logCollector:
+            sidecarName: typo-collector
+            readyCommand: "test -f /x"
+            stopCommand: "pkill fluent-bit"
+    asserts:
+      - failedTemplate:
+          errorPattern: "does not match any configured sidecar"

--- a/charts/spartan/values.yaml
+++ b/charts/spartan/values.yaml
@@ -395,6 +395,10 @@ hooks:
 #    # Optional: swap the log-collector sidecar used when collectLog is true.
 #    # Defaults reproduce the Datadog Agent behavior; override for a lightweight
 #    # collector (e.g. Fluent Bit) to avoid pulling the ~1GB agent image on the hook.
+#    # When sidecarName is NOT "datadog-agent", BOTH readyCommand and stopCommand are
+#    # required (template fails otherwise) - the datadog-agent defaults (:8126 wait,
+#    # pkill agent) would otherwise hang against a different collector. readyCommand /
+#    # stopCommand are shell snippets run verbatim; do not embed single quotes.
 #    logCollector:
 #      sidecarName: log-collector          # must match a sidecars[].name; default "datadog-agent"
 #      readyCommand: "while ! curl -Ns localhost:2020/api/v1/health; do sleep 1; done"

--- a/charts/spartan/values.yaml
+++ b/charts/spartan/values.yaml
@@ -392,6 +392,13 @@ hooks:
 #    - name: SERVICE
 #      value: hook
 #    collectLog: false
+#    # Optional: swap the log-collector sidecar used when collectLog is true.
+#    # Defaults reproduce the Datadog Agent behavior; override for a lightweight
+#    # collector (e.g. Fluent Bit) to avoid pulling the ~1GB agent image on the hook.
+#    logCollector:
+#      sidecarName: log-collector          # must match a sidecars[].name; default "datadog-agent"
+#      readyCommand: "while ! curl -Ns localhost:2020/api/v1/health; do sleep 1; done"
+#      stopCommand: "sleep 5 && pkill fluent-bit"
 
 ## cronjobs specifies list of cronjobs
 cronjobs: []
@@ -444,6 +451,17 @@ sidecars: []
 #    extraEnvs:
 #      - name: SERVICE
 #        value: sidecar
+#  - name: log-collector
+#    image: fluent/fluent-bit:3.1.9
+#    sharedVolume:
+#      mountPath: /var/log/application/
+#    resources:
+#      requests:
+#        memory: 64Mi
+#        cpu: 50m
+#      limits:
+#        memory: 128Mi
+#        cpu: 200m
 #  - name: busybox
 #    image: busybox
 #    ports:

--- a/charts/spartan/values.yaml
+++ b/charts/spartan/values.yaml
@@ -457,6 +457,10 @@ sidecars: []
 #        value: sidecar
 #  - name: log-collector
 #    image: fluent/fluent-bit:3.1.9
+#    # skipDeployment attaches this sidecar to hook Jobs only, never the Deployment.
+#    # Use for a hook-scoped log collector so the long-running pod keeps its own
+#    # sidecar set (e.g. the Datadog Agent for APM) unchanged. Default false.
+#    skipDeployment: true
 #    sharedVolume:
 #      mountPath: /var/log/application/
 #    resources:


### PR DESCRIPTION
## Summary

Make the hook (migration Job) log collector pluggable so a lightweight sidecar (e.g. Fluent Bit, ~tens of MB) can collect the migration log instead of the full Datadog Agent image (~1GB). On nodes with no image cache (e.g. EKS Fargate) the short-lived hook Job pulls the collector image on every run, so image size sits directly on the rollout critical path.

Fully backward compatible: with no `logCollector` set, the rendered Deployment and hook Job are **byte-identical** to 0.4.0.

```mermaid
flowchart LR
    subgraph d["Deployment (long-running)"]
        A["app container"] -.->|shared PID ns| DD["datadog-agent<br/>(APM)"]
    end
    subgraph h["Hook Job (migration)"]
        M["migration<br/>readyCommand · stopCommand"] -.->|shared PID ns| C["logCollector sidecar<br/>DD agent (default) OR Fluent Bit"]
    end
```

## What changed

1. **`logCollector` block on a hook** - three optional knobs, each defaulting to today's Datadog Agent behavior:
   - `sidecarName` (default `datadog-agent`) - which sidecar to attach + whether to inject `DD_*` env
   - `readyCommand` (default the DD APM `:8126` wait) - how the migration container waits for the collector
   - `stopCommand` (default `sleep 10 && pkill agent`) - the EXIT-trap that stops the collector
   - Fails fast at template time if a non-`datadog-agent` collector omits `readyCommand`/`stopCommand`, or if `sidecarName` matches no configured sidecar.
2. **`sidecars[].skipDeployment`** (default false) - attach a sidecar to hook Jobs only, never the Deployment. Lets a hook-scoped collector run on the migration Job while the long-running pod keeps its own sidecar set (e.g. the DD agent for APM).
3. **Hook shared-volume mount scoped to the collector** - the migration container now mounts the shared log volume only for the hook's collector sidecar, avoiding a duplicate `mountPath` when more than one sidecar defines `sharedVolume`.

## Types of Changes

- [x] New feature (non-breaking change which adds functionality)

## Test Plan:

- **Backward-compat:** `helm template` on the Deployment and a Datadog-agent hook renders byte-identically to 0.4.0 (only the `helm.sh/chart` version label differs).
- **New path (unit tests in `hook_test.yaml` / `deployment_test.yaml`):** a Fluent-Bit-style collector renders the custom `readyCommand`/`stopCommand`, attaches the named sidecar, injects no `DD_*` env, keeps `shareProcessNamespace: true`; a `skipDeployment` sidecar is absent from the Deployment but present on the hook; misconfigurations fail the template.
- `helm lint` clean; `helm unittest` green in CI.
- Verified end-to-end on a real Fargate migration Job: Fluent Bit tails the migration log, ships to Datadog, and flushes cleanly on SIGTERM; image-pull portion of `ContainerCreating` dropped substantially vs the ~1GB agent.

## Jira Issues:

N/A
