### PR TITLE
feat(spartan): add datadog cluster-agent + orchestrator-explorer toggles (default true)

### DIFF
--- a/charts/spartan/CHANGELOG.md
+++ b/charts/spartan/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.6.0](https://github.com/spartan-stratos/helm-charts/releases/tag/spartan-0.6.0) (2026-07-09)
+
+### Features
+
+* Add `datadog.clusterAgentEnabled` (default `true`) to toggle `DD_CLUSTER_AGENT_ENABLED` on the datadog-agent containers (sidecar / worker / hook / cronjob / deployment)
+  * Set to `false` for per-pod agents that have no Datadog Cluster Agent connection wired in (e.g. EKS Fargate sidecars), stopping the recurring `failed to load cluster agent auth token: ... cluster_agent.auth_token: no such file or directory` error the agent logs on every retry
+  * Fully backward compatible: with the value unset the rendered manifests are byte-identical to 0.5.0 (`DD_CLUSTER_AGENT_ENABLED` still `"true"`)
+
 ## [0.5.0](https://github.com/spartan-stratos/helm-charts/releases/tag/spartan-0.5.0) (2026-07-07)
 
 ### Features

--- a/charts/spartan/CHANGELOG.md
+++ b/charts/spartan/CHANGELOG.md
@@ -6,9 +6,9 @@ All notable changes to this project will be documented in this file.
 
 ### Features
 
-* Add `datadog.clusterAgentEnabled` (default `true`) to toggle `DD_CLUSTER_AGENT_ENABLED` on the datadog-agent containers (sidecar / worker / hook / cronjob / deployment)
-  * Set to `false` for per-pod agents that have no Datadog Cluster Agent connection wired in (e.g. EKS Fargate sidecars), stopping the recurring `failed to load cluster agent auth token: ... cluster_agent.auth_token: no such file or directory` error the agent logs on every retry
-  * Fully backward compatible: with the value unset the rendered manifests are byte-identical to 0.5.0 (`DD_CLUSTER_AGENT_ENABLED` still `"true"`)
+* Add `datadog.clusterAgentEnabled` and `datadog.orchestratorExplorerEnabled` (both default `true`) to toggle `DD_CLUSTER_AGENT_ENABLED` and `DD_ORCHESTRATOR_EXPLORER_ENABLED` on the datadog-agent containers (sidecar / worker / hook / cronjob / deployment)
+  * Set both to `false` for per-pod agents that have no Datadog Cluster Agent connection wired in (e.g. EKS Fargate sidecars). This stops two coupled log-spam sources: the `failed to load cluster agent auth token: ... cluster_agent.auth_token: no such file or directory` error, and the `Cluster Agent not ready yet, skipping orchestrator_pod check` warnings/errors. The Orchestrator Explorer requires the Cluster Agent, so it is non-functional on such agents regardless
+  * Fully backward compatible: with the values unset the rendered manifests are byte-identical to 0.5.0 (both env vars still `"true"`)
 
 ## [0.5.0](https://github.com/spartan-stratos/helm-charts/releases/tag/spartan-0.5.0) (2026-07-07)
 

--- a/charts/spartan/Chart.yaml
+++ b/charts/spartan/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.0
+version: 0.6.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/spartan/templates/_cronjob.tpl
+++ b/charts/spartan/templates/_cronjob.tpl
@@ -126,7 +126,7 @@ spec:
                 - name: DD_PROCESS_AGENT_ENABLED
                   value: "true"
                 - name: DD_CLUSTER_AGENT_ENABLED
-                  value: "true"
+                  value: {{ .Values.datadog.clusterAgentEnabled | quote }}
               {{- end }}
               {{- if or .Values.extraEnvs .cronjob.extraEnvs }}
                 {{- include "spartan.extraEnvs" (dict "lists" (list .Values.extraEnvs .cronjob.extraEnvs)) | nindent 16 }}

--- a/charts/spartan/templates/_cronjob.tpl
+++ b/charts/spartan/templates/_cronjob.tpl
@@ -122,7 +122,7 @@ spec:
                 - name: DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL
                   value: "true"
                 - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
-                  value: "true"
+                  value: {{ .Values.datadog.orchestratorExplorerEnabled | quote }}
                 - name: DD_PROCESS_AGENT_ENABLED
                   value: "true"
                 - name: DD_CLUSTER_AGENT_ENABLED

--- a/charts/spartan/templates/_hook.tpl
+++ b/charts/spartan/templates/_hook.tpl
@@ -121,7 +121,7 @@ spec:
             - name: DD_PROCESS_AGENT_ENABLED
               value: "true"
             - name: DD_CLUSTER_AGENT_ENABLED
-              value: "true"
+              value: {{ .Values.datadog.clusterAgentEnabled | quote }}
           {{- end }}
           {{- if or .Values.extraEnvs .hook.extraEnvs }}
           {{- include "spartan.extraEnvs" (dict "lists" (list .Values.extraEnvs .hook.extraEnvs)) | nindent 12 }}

--- a/charts/spartan/templates/_hook.tpl
+++ b/charts/spartan/templates/_hook.tpl
@@ -117,7 +117,7 @@ spec:
             - name: DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL
               value: "true"
             - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
-              value: "true"
+              value: {{ .Values.datadog.orchestratorExplorerEnabled | quote }}
             - name: DD_PROCESS_AGENT_ENABLED
               value: "true"
             - name: DD_CLUSTER_AGENT_ENABLED

--- a/charts/spartan/templates/_sidecar.tpl
+++ b/charts/spartan/templates/_sidecar.tpl
@@ -44,7 +44,7 @@
     - name: DD_PROCESS_AGENT_ENABLED
       value: "true"
     - name: DD_CLUSTER_AGENT_ENABLED
-      value: "true"
+      value: {{ .Values.datadog.clusterAgentEnabled | quote }}
   {{- end }}
   {{- if or .Values.extraEnvs .sidecar.extraEnvs }}
   {{- include "spartan.extraEnvs" (dict "lists" (list .Values.extraEnvs .sidecar.extraEnvs)) | nindent 4 }}

--- a/charts/spartan/templates/_sidecar.tpl
+++ b/charts/spartan/templates/_sidecar.tpl
@@ -40,7 +40,7 @@
     - name: DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL
       value: "true"
     - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
-      value: "true"
+      value: {{ .Values.datadog.orchestratorExplorerEnabled | quote }}
     - name: DD_PROCESS_AGENT_ENABLED
       value: "true"
     - name: DD_CLUSTER_AGENT_ENABLED

--- a/charts/spartan/templates/_worker.tpl
+++ b/charts/spartan/templates/_worker.tpl
@@ -91,7 +91,7 @@ spec:
             - name: DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL
               value: "true"
             - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
-              value: "true"
+              value: {{ .Values.datadog.orchestratorExplorerEnabled | quote }}
             - name: DD_PROCESS_AGENT_ENABLED
               value: "true"
             - name: DD_CLUSTER_AGENT_ENABLED

--- a/charts/spartan/templates/_worker.tpl
+++ b/charts/spartan/templates/_worker.tpl
@@ -95,7 +95,7 @@ spec:
             - name: DD_PROCESS_AGENT_ENABLED
               value: "true"
             - name: DD_CLUSTER_AGENT_ENABLED
-              value: "true"
+              value: {{ .Values.datadog.clusterAgentEnabled | quote }}
           {{- end }}
           {{- if or .Values.extraEnvs .worker.extraEnvs }}
           {{- include "spartan.extraEnvs" (dict "lists" (list .Values.extraEnvs .worker.extraEnvs)) | nindent 12 }}

--- a/charts/spartan/templates/deployment.yaml
+++ b/charts/spartan/templates/deployment.yaml
@@ -112,7 +112,7 @@ spec:
             - name: DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL
               value: "true"
             - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
-              value: "true"
+              value: {{ .Values.datadog.orchestratorExplorerEnabled | quote }}
             - name: DD_PROCESS_AGENT_ENABLED
               value: "true"
             - name: DD_CLUSTER_AGENT_ENABLED

--- a/charts/spartan/templates/deployment.yaml
+++ b/charts/spartan/templates/deployment.yaml
@@ -116,7 +116,7 @@ spec:
             - name: DD_PROCESS_AGENT_ENABLED
               value: "true"
             - name: DD_CLUSTER_AGENT_ENABLED
-              value: "true"
+              value: {{ .Values.datadog.clusterAgentEnabled | quote }}
           {{- end }}
           {{- if .Values.extraEnvs }}
           {{- include "spartan.extraEnvs" (dict "lists" (list .Values.extraEnvs)) | nindent 12 }}

--- a/charts/spartan/tests/deployment_test.yaml
+++ b/charts/spartan/tests/deployment_test.yaml
@@ -87,7 +87,7 @@ tests:
             mountPath: /var/log/application/
             subPath: log-collector
 
-  - it: "datadog.clusterAgentEnabled defaults to true"
+  - it: "datadog cluster-agent and orchestrator-explorer toggles default to true"
     template: "templates/deployment.yaml"
     set:
       datadog:
@@ -98,18 +98,29 @@ tests:
           content:
             name: DD_CLUSTER_AGENT_ENABLED
             value: "true"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DD_ORCHESTRATOR_EXPLORER_ENABLED
+            value: "true"
 
-  - it: "datadog.clusterAgentEnabled=false disables the cluster agent connection"
+  - it: "disabling clusterAgentEnabled + orchestratorExplorerEnabled silences the cluster-agent noise"
     template: "templates/deployment.yaml"
     set:
       datadog:
         enabled: true
         clusterAgentEnabled: false
+        orchestratorExplorerEnabled: false
     asserts:
       - contains:
           path: spec.template.spec.containers[0].env
           content:
             name: DD_CLUSTER_AGENT_ENABLED
+            value: "false"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DD_ORCHESTRATOR_EXPLORER_ENABLED
             value: "false"
       - notContains:
           path: spec.template.spec.containers[0].env

--- a/charts/spartan/tests/deployment_test.yaml
+++ b/charts/spartan/tests/deployment_test.yaml
@@ -86,3 +86,33 @@ tests:
             readOnly: false
             mountPath: /var/log/application/
             subPath: log-collector
+
+  - it: "datadog.clusterAgentEnabled defaults to true"
+    template: "templates/deployment.yaml"
+    set:
+      datadog:
+        enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DD_CLUSTER_AGENT_ENABLED
+            value: "true"
+
+  - it: "datadog.clusterAgentEnabled=false disables the cluster agent connection"
+    template: "templates/deployment.yaml"
+    set:
+      datadog:
+        enabled: true
+        clusterAgentEnabled: false
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DD_CLUSTER_AGENT_ENABLED
+            value: "false"
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DD_CLUSTER_AGENT_ENABLED
+            value: "true"

--- a/charts/spartan/values.yaml
+++ b/charts/spartan/values.yaml
@@ -496,6 +496,12 @@ datadog:
   ## the Datadog Cluster Agent (e.g. Fargate sidecars) to stop the recurring
   ## "failed to load cluster agent auth token" error when no token is wired in.
   clusterAgentEnabled: true
+  ## orchestratorExplorerEnabled toggles DD_ORCHESTRATOR_EXPLORER_ENABLED. The
+  ## Orchestrator Explorer requires the Cluster Agent, so a per-pod agent with no
+  ## Cluster Agent connection emits its own "Cluster Agent not ready, skipping
+  ## orchestrator_pod check" noise. Set this false alongside clusterAgentEnabled
+  ## on such agents; leaving it true there is non-functional and only adds log spam.
+  orchestratorExplorerEnabled: true
 
 ## StrategyType configuration
 ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy

--- a/charts/spartan/values.yaml
+++ b/charts/spartan/values.yaml
@@ -490,6 +490,12 @@ sidecars: []
 ## It will also add stop condition for datadog agent container
 datadog:
   enabled: false
+  ## clusterAgentEnabled toggles DD_CLUSTER_AGENT_ENABLED on the datadog-agent
+  ## containers (sidecar/worker/hook/cronjob/deployment). Defaults to true to
+  ## preserve existing behavior. Set to false for per-pod agents that do not need
+  ## the Datadog Cluster Agent (e.g. Fargate sidecars) to stop the recurring
+  ## "failed to load cluster agent auth token" error when no token is wired in.
+  clusterAgentEnabled: true
 
 ## StrategyType configuration
 ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy

--- a/charts/spartan/values.yaml
+++ b/charts/spartan/values.yaml
@@ -490,17 +490,11 @@ sidecars: []
 ## It will also add stop condition for datadog agent container
 datadog:
   enabled: false
-  ## clusterAgentEnabled toggles DD_CLUSTER_AGENT_ENABLED on the datadog-agent
-  ## containers (sidecar/worker/hook/cronjob/deployment). Defaults to true to
-  ## preserve existing behavior. Set to false for per-pod agents that do not need
-  ## the Datadog Cluster Agent (e.g. Fargate sidecars) to stop the recurring
-  ## "failed to load cluster agent auth token" error when no token is wired in.
+  ## Set false for per-pod agents with no Cluster Agent token (e.g. Fargate
+  ## sidecars) to stop the recurring cluster-agent auth-token error.
   clusterAgentEnabled: true
-  ## orchestratorExplorerEnabled toggles DD_ORCHESTRATOR_EXPLORER_ENABLED. The
-  ## Orchestrator Explorer requires the Cluster Agent, so a per-pod agent with no
-  ## Cluster Agent connection emits its own "Cluster Agent not ready, skipping
-  ## orchestrator_pod check" noise. Set this false alongside clusterAgentEnabled
-  ## on such agents; leaving it true there is non-functional and only adds log spam.
+  ## Orchestrator Explorer requires the Cluster Agent; disable it alongside
+  ## clusterAgentEnabled on per-pod agents to stop the orchestrator-check spam.
   orchestratorExplorerEnabled: true
 
 ## StrategyType configuration


### PR DESCRIPTION
## What

Adds two `datadog` values, both default `true`, parameterizing the two cluster-agent-dependent env vars on the datadog-agent containers across all five renderers (`_sidecar.tpl`, `_worker.tpl`, `_hook.tpl`, `_cronjob.tpl`, `deployment.yaml`):

- `datadog.clusterAgentEnabled` -> `DD_CLUSTER_AGENT_ENABLED`
- `datadog.orchestratorExplorerEnabled` -> `DD_ORCHESTRATOR_EXPLORER_ENABLED`

## Why

The datadog-agent runs as a per-pod sidecar on EKS Fargate workloads (Fargate has no node for the agent DaemonSet). Those sidecars point at the Cluster Agent but have no auth token wired in (the token secret lives in the `datadog` namespace and is not replicated into app namespaces). The agent then spams **two coupled sources** on every retry:

```
# clusterAgentClient / kube metadata collector (~196 lines / 30m / pod)
Could not initialise the communication with the cluster agent: ... failed to load cluster agent auth token: unable to read artifact: open /etc/datadog-agent/cluster_agent.auth_token: no such file or directory

# orchestrator explorer checks (~123 lines / 30m / pod)
Cluster Agent not ready yet, skipping orchestrator_pod check run: temporary failure in clusterAgentClient ...
```

Both features **require the Cluster Agent** (per Datadog docs, Orchestrator/Kubernetes Explorer needs Cluster Agent 1.11.0+) and are non-functional on a per-pod sidecar regardless. Disabling only the first flag leaves the orchestrator noise running, so both are needed to fully silence it. Pod/deployment/namespace tags come from the local kubelet tagger and logs/traces/metrics post directly to intake, so the only loss is `kube_service` tags + Live Containers/Orchestrator view for those pods.

## Backward compatibility

Both default `true` - with the values unset, rendered manifests are **byte-identical to 0.5.0**. Verified via `helm template` (default renders `"true"`; both `--set ...=false` render `"false"`).

## Tests

`helm-unittest` covers both defaults-true and both-disabled. Full suite green:

```
Test Suites: 4 passed, 4 total
Tests:       28 passed, 28 total
```

Chart version bumped 0.5.0 -> 0.6.0 (chart-releaser packages on the Chart.yaml version).