### PR TITLE
feat(spartan): add datadog.cloudProviderMetadataEnabled toggle (default true)

### DIFF
--- a/charts/spartan/CHANGELOG.md
+++ b/charts/spartan/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.7.0](https://github.com/spartan-stratos/helm-charts/releases/tag/spartan-0.7.0) (2026-07-09)
+
+### Features
+
+* Add `datadog.cloudProviderMetadataEnabled` (default `true`) across the datadog-agent renderers (sidecar / worker / hook / cronjob / deployment)
+  * Set to `false` on EKS Fargate, where the pod cannot reach the EC2 IMDS (`169.254.169.254`). It renders `DD_CLOUD_PROVIDER_METADATA=""`, so the agent stops probing IMDS and logging `Could not fetch instance type for AWS: ... context deadline exceeded`
+  * Fully backward compatible: with the value unset no env var is added, so rendered manifests are byte-identical to 0.6.0
+
 ## [0.6.0](https://github.com/spartan-stratos/helm-charts/releases/tag/spartan-0.6.0) (2026-07-09)
 
 ### Features

--- a/charts/spartan/Chart.yaml
+++ b/charts/spartan/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.0
+version: 0.7.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/spartan/templates/_cronjob.tpl
+++ b/charts/spartan/templates/_cronjob.tpl
@@ -127,6 +127,10 @@ spec:
                   value: "true"
                 - name: DD_CLUSTER_AGENT_ENABLED
                   value: {{ .Values.datadog.clusterAgentEnabled | quote }}
+                {{- if not .Values.datadog.cloudProviderMetadataEnabled }}
+                - name: DD_CLOUD_PROVIDER_METADATA
+                  value: ""
+                {{- end }}
               {{- end }}
               {{- if or .Values.extraEnvs .cronjob.extraEnvs }}
                 {{- include "spartan.extraEnvs" (dict "lists" (list .Values.extraEnvs .cronjob.extraEnvs)) | nindent 16 }}

--- a/charts/spartan/templates/_hook.tpl
+++ b/charts/spartan/templates/_hook.tpl
@@ -122,6 +122,10 @@ spec:
               value: "true"
             - name: DD_CLUSTER_AGENT_ENABLED
               value: {{ .Values.datadog.clusterAgentEnabled | quote }}
+            {{- if not .Values.datadog.cloudProviderMetadataEnabled }}
+            - name: DD_CLOUD_PROVIDER_METADATA
+              value: ""
+            {{- end }}
           {{- end }}
           {{- if or .Values.extraEnvs .hook.extraEnvs }}
           {{- include "spartan.extraEnvs" (dict "lists" (list .Values.extraEnvs .hook.extraEnvs)) | nindent 12 }}

--- a/charts/spartan/templates/_sidecar.tpl
+++ b/charts/spartan/templates/_sidecar.tpl
@@ -45,6 +45,10 @@
       value: "true"
     - name: DD_CLUSTER_AGENT_ENABLED
       value: {{ .Values.datadog.clusterAgentEnabled | quote }}
+    {{- if not .Values.datadog.cloudProviderMetadataEnabled }}
+    - name: DD_CLOUD_PROVIDER_METADATA
+      value: ""
+    {{- end }}
   {{- end }}
   {{- if or .Values.extraEnvs .sidecar.extraEnvs }}
   {{- include "spartan.extraEnvs" (dict "lists" (list .Values.extraEnvs .sidecar.extraEnvs)) | nindent 4 }}

--- a/charts/spartan/templates/_worker.tpl
+++ b/charts/spartan/templates/_worker.tpl
@@ -96,6 +96,10 @@ spec:
               value: "true"
             - name: DD_CLUSTER_AGENT_ENABLED
               value: {{ .Values.datadog.clusterAgentEnabled | quote }}
+            {{- if not .Values.datadog.cloudProviderMetadataEnabled }}
+            - name: DD_CLOUD_PROVIDER_METADATA
+              value: ""
+            {{- end }}
           {{- end }}
           {{- if or .Values.extraEnvs .worker.extraEnvs }}
           {{- include "spartan.extraEnvs" (dict "lists" (list .Values.extraEnvs .worker.extraEnvs)) | nindent 12 }}

--- a/charts/spartan/templates/deployment.yaml
+++ b/charts/spartan/templates/deployment.yaml
@@ -117,6 +117,10 @@ spec:
               value: "true"
             - name: DD_CLUSTER_AGENT_ENABLED
               value: {{ .Values.datadog.clusterAgentEnabled | quote }}
+            {{- if not .Values.datadog.cloudProviderMetadataEnabled }}
+            - name: DD_CLOUD_PROVIDER_METADATA
+              value: ""
+            {{- end }}
           {{- end }}
           {{- if .Values.extraEnvs }}
           {{- include "spartan.extraEnvs" (dict "lists" (list .Values.extraEnvs)) | nindent 12 }}

--- a/charts/spartan/tests/deployment_test.yaml
+++ b/charts/spartan/tests/deployment_test.yaml
@@ -146,9 +146,21 @@ tests:
       datadog:
         enabled: true
         cloudProviderMetadataEnabled: false
+      sidecars:
+        - name: datadog-agent
+          image: datadog/agent
+          sharedVolume:
+            mountPath: /var/log/application/
     asserts:
+      # primary container (deployment.yaml renderer)
       - contains:
           path: spec.template.spec.containers[0].env
+          content:
+            name: DD_CLOUD_PROVIDER_METADATA
+            value: ""
+      # datadog-agent sidecar (_sidecar.tpl renderer)
+      - contains:
+          path: spec.template.spec.containers[1].env
           content:
             name: DD_CLOUD_PROVIDER_METADATA
             value: ""

--- a/charts/spartan/tests/deployment_test.yaml
+++ b/charts/spartan/tests/deployment_test.yaml
@@ -127,3 +127,28 @@ tests:
           content:
             name: DD_CLUSTER_AGENT_ENABLED
             value: "true"
+
+  - it: "cloudProviderMetadataEnabled defaults to true and adds no DD_CLOUD_PROVIDER_METADATA env"
+    template: "templates/deployment.yaml"
+    set:
+      datadog:
+        enabled: true
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DD_CLOUD_PROVIDER_METADATA
+            value: ""
+
+  - it: "cloudProviderMetadataEnabled=false disables IMDS probing via empty DD_CLOUD_PROVIDER_METADATA"
+    template: "templates/deployment.yaml"
+    set:
+      datadog:
+        enabled: true
+        cloudProviderMetadataEnabled: false
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DD_CLOUD_PROVIDER_METADATA
+            value: ""

--- a/charts/spartan/values.yaml
+++ b/charts/spartan/values.yaml
@@ -496,6 +496,11 @@ datadog:
   ## Orchestrator Explorer requires the Cluster Agent; disable it alongside
   ## clusterAgentEnabled on per-pod agents to stop the orchestrator-check spam.
   orchestratorExplorerEnabled: true
+  ## Set false on EKS Fargate, where the pod cannot reach the EC2 IMDS
+  ## (169.254.169.254); this renders DD_CLOUD_PROVIDER_METADATA="" so the agent
+  ## stops probing IMDS and logging "Could not fetch instance type ... context
+  ## deadline exceeded". Default true keeps the current behavior (no env added).
+  cloudProviderMetadataEnabled: true
 
 ## StrategyType configuration
 ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy


### PR DESCRIPTION
## What
Adds `datadog.cloudProviderMetadataEnabled` (default `true`) across all five datadog-agent renderers (`_sidecar.tpl`, `_worker.tpl`, `_hook.tpl`, `_cronjob.tpl`, `deployment.yaml`).

## Why
On EKS Fargate the pod cannot reach the EC2 Instance Metadata Service (`169.254.169.254`) - there is no node IMDS exposed to the pod. The datadog-agent's cloud-provider detection probes it anyway and logs on every retry:

```
Could not fetch instance type for AWS: Get "http://169.254.169.254/latest/meta-data/instance-type": context deadline exceeded
```

`DD_EKS_FARGATE=true` does not suppress this probe. Setting `cloudProviderMetadataEnabled: false` renders `DD_CLOUD_PROVIDER_METADATA=""`, disabling all cloud-provider metadata lookups and stopping the IMDS timeout noise. Safe on Fargate: instance type/hostname come from the pod, and EKS cluster name should come from `DD_CLUSTER_NAME`/the cluster agent, not IMDS tags.

## Backward compatibility
Default `true` **adds no env var** - manifests are byte-identical to 0.6.0. Verified via helm template (default: 0 occurrences; disabled: renders `DD_CLOUD_PROVIDER_METADATA=""` across CronJob/Deployment/Job).

## Tests
Two helm-unittest cases (default = absent; disabled = present with `""`). Suite green: 30/30. Chart 0.6.0 -> 0.7.0.