### PR TITLE
feat(spartan): render sidecars[].lifecycle for ordered shutdown (0.9.0)

### DIFF
--- a/charts/spartan/CHANGELOG.md
+++ b/charts/spartan/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.9.0](https://github.com/spartan-stratos/helm-charts/releases/tag/spartan-0.9.0) (2026-07-11)
+
+### Features
+
+* Render `sidecars[].lifecycle` (postStart / preStop) on sidecar containers
+  * Motivation: on pod termination all containers get SIGTERM concurrently, so a fast-exiting sidecar (e.g. the datadog-agent) can stop listening before the main app finishes its graceful shutdown - the app's final DogStatsD/trace sends then hit a dead port (`PortUnreachableException` on `:8125`). A `preStop` sleep on the sidecar keeps it alive through the app's drain window, ordering the shutdown without a fixed guess elsewhere
+  * Example: `sidecars: [{name: datadog-agent, ..., lifecycle: {preStop: {exec: {command: ["/bin/sleep","15"]}}}}]` (keep the sleep < `terminationGracePeriodSeconds`)
+  * Fully backward compatible: with no `sidecars[].lifecycle` set, rendered manifests are byte-identical to 0.8.0
+
 ## [0.8.0](https://github.com/spartan-stratos/helm-charts/releases/tag/spartan-0.8.0) (2026-07-11)
 
 ### Features

--- a/charts/spartan/Chart.yaml
+++ b/charts/spartan/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: 0.4.0
 description: A Helm chart for Kubernetes
 name: spartan
 type: application
-version: 0.8.0
+version: 0.9.0

--- a/charts/spartan/templates/_sidecar.tpl
+++ b/charts/spartan/templates/_sidecar.tpl
@@ -65,6 +65,9 @@
   {{- if .sidecar.resources }}
   resources: {{- toYaml .sidecar.resources | nindent 4 }}
   {{- end }}
+  {{- if .sidecar.lifecycle }}
+  lifecycle: {{- toYaml .sidecar.lifecycle | nindent 4 }}
+  {{- end }}
   volumeMounts:
   {{- if .Values.secret.asFile.enabled }}
     - name: {{ include "spartan.secretAsFile" . }}

--- a/charts/spartan/tests/deployment_test.yaml
+++ b/charts/spartan/tests/deployment_test.yaml
@@ -87,6 +87,34 @@ tests:
             mountPath: /var/log/application/
             subPath: log-collector
 
+  - it: "renders sidecars[].lifecycle (preStop) on the sidecar container"
+    template: "templates/deployment.yaml"
+    set:
+      sidecars:
+        - name: datadog-agent
+          image: datadog/agent
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sleep", "15"]
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[1].name
+          value: datadog-agent
+      - equal:
+          path: spec.template.spec.containers[1].lifecycle.preStop.exec.command
+          value: ["/bin/sleep", "15"]
+
+  - it: "omits lifecycle on sidecars when unset (backward compatible)"
+    template: "templates/deployment.yaml"
+    set:
+      sidecars:
+        - name: datadog-agent
+          image: datadog/agent
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[1].lifecycle
+
   - it: "datadog cluster-agent and orchestrator-explorer toggles default to true"
     template: "templates/deployment.yaml"
     set:

--- a/charts/spartan/values.yaml
+++ b/charts/spartan/values.yaml
@@ -470,6 +470,14 @@ sidecars: []
 #    extraEnvs:
 #      - name: SERVICE
 #        value: sidecar
+#    # lifecycle (postStart/preStop) is passed through verbatim. A preStop sleep keeps
+#    # a fast-exiting sidecar (e.g. the datadog-agent) alive through the main app's
+#    # graceful-shutdown window, so the app's final DogStatsD/trace sends don't hit a
+#    # dead port on termination. Keep the sleep < terminationGracePeriodSeconds.
+#    lifecycle:
+#      preStop:
+#        exec:
+#          command: ["/bin/sleep", "15"]
 #  - name: log-collector
 #    image: fluent/fluent-bit:3.1.9
 #    # skipDeployment attaches this sidecar to hook Jobs only, never the Deployment.


### PR DESCRIPTION
## What
Renders `sidecars[].lifecycle` (postStart / preStop) on sidecar containers. Passed through verbatim; no behavior when unset.

## Why
On pod termination all containers receive SIGTERM concurrently. A fast-exiting sidecar (e.g. the datadog-agent) can stop listening before the main app finishes its graceful shutdown, so the app's final DogStatsD/trace sends hit a dead port - e.g. `java.net.PortUnreachableException` on `:8125` ("An exception has been observed post termination"). A `preStop` sleep on the sidecar keeps it alive through the app's drain window, ordering the shutdown at the source.

## How
`_sidecar.tpl` now emits `lifecycle` when a sidecar sets it:
```yaml
sidecars:
  - name: datadog-agent
    image: datadog/agent
    lifecycle:
      preStop:
        exec:
          command: ["/bin/sleep", "15"]   # keep < terminationGracePeriodSeconds
```

## Compatibility
Fully backward compatible: with no `sidecars[].lifecycle`, rendered manifests are byte-identical to 0.8.0.

## Verification
- `helm lint` clean; `helm unittest` 35 passing (+2 new: lifecycle renders / omitted when unset)
- Rendered deployment confirmed: `preStop.exec.command` present on the sidecar container