### PR TITLE
fix(spartan): exclude skipDeployment sidecars from the cronjob pod

### DIFF
--- a/charts/spartan/CHANGELOG.md
+++ b/charts/spartan/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.9.1](https://github.com/spartan-stratos/helm-charts/releases/tag/spartan-0.9.1) (2026-07-14)
+
+### Bug Fixes
+
+* CronJob: skip `sidecars[].skipDeployment` sidecars on the cronjob pod, matching the Deployment
+  * `deployment.yaml` already filters `skipDeployment` sidecars out of both the shared-volume mount loop (`if and .sharedVolume (not .skipDeployment)`) and the sidecar-container injection loop (`if not $sidecar.skipDeployment`); `_cronjob.tpl` did not, so a `skipDeployment` sidecar (e.g. a hook-only `log-collector`) was still injected into the cronjob pod and its `sharedVolume` still mounted on the cronjob container
+  * Impact: a service with BOTH a cronjob AND two sidecars whose `sharedVolume.mountPath` collide (e.g. `datadog-agent` + a Fluent Bit `log-collector` both at `/var/log/application/`) rendered a cronjob container with duplicate `volumeMounts` for that path. `helm template` does not validate it, but Kubernetes server-side apply rejects it (`failed to create typed patch object ... duplicate entries for key [mountPath=...]`), which breaks ArgoCD's server-side diff and stalls the sync. Now the cronjob excludes hook-only sidecars, matching the documented `skipDeployment` intent ("attach to hook Jobs only")
+  * Backward compatible: sidecars without `skipDeployment` (e.g. `datadog-agent`) are unchanged on the cronjob; only `skipDeployment: true` sidecars change (now excluded, as on the Deployment)
+
 ## [0.9.0](https://github.com/spartan-stratos/helm-charts/releases/tag/spartan-0.9.0) (2026-07-11)
 
 ### Features

--- a/charts/spartan/Chart.yaml
+++ b/charts/spartan/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: 0.4.0
 description: A Helm chart for Kubernetes
 name: spartan
 type: application
-version: 0.9.0
+version: 0.9.1

--- a/charts/spartan/templates/_cronjob.tpl
+++ b/charts/spartan/templates/_cronjob.tpl
@@ -161,7 +161,7 @@ spec:
                   mountPath: {{ .mountPath }}
               {{- end }}
               {{- range .Values.sidecars }}
-              {{- if .sharedVolume }}
+              {{- if and .sharedVolume (not .skipDeployment) }}
                 - name: sidecar-volume
                   readOnly: false
                   mountPath: {{ .sharedVolume.mountPath }}
@@ -169,7 +169,9 @@ spec:
               {{- end }}
               {{- end }}
             {{- range $sidecar := .Values.sidecars }}
+            {{- if not $sidecar.skipDeployment }}
             {{ include "sidecar.template" (dict "sidecar" $sidecar "Values" $.Values "Chart" $.Chart "Release" $.Release) | indent 12 }}
+            {{- end }}
             {{- end }}
           {{- with .Values.nodeSelector }}
           nodeSelector:


### PR DESCRIPTION
## What

`_cronjob.tpl` now filters `sidecars[].skipDeployment` sidecars out of the cronjob pod, matching what `deployment.yaml` already does:
- the shared-volume mount loop: `if and .sharedVolume (not .skipDeployment)`
- the sidecar-container injection loop: `if not $sidecar.skipDeployment`

## Why

`deployment.yaml` already excludes `skipDeployment` sidecars from both loops, but `_cronjob.tpl` did not. A hook-only sidecar (e.g. a `log-collector` marked `skipDeployment: true`, intended only for a migration hook) was therefore still injected into the cronjob pod, and its `sharedVolume` still mounted on the cronjob container. When another sidecar (e.g. `datadog-agent`) shares the same `mountPath`, the cronjob container ends up with two identical `volumeMount`s. `helm template` doesn't catch it, but Kubernetes server-side apply rejects it (`duplicate entries for key [mountPath=...]`), which surfaces as an ArgoCD ComparisonError and stalls the sync.

## Verification

- `helm template` of a chart consumer with a `skipDeployment` log-collector: the sidecar is no longer rendered onto the cronjob, and the cronjob container's shared-volume mount count drops from 2 to 1.
- `kubectl apply --server-side --dry-run=server` of the rendered CronJob is now clean (previously failed with the duplicate-key error).
- Published as `0.9.1-rc.1` and exercised end-to-end on a live cluster: ArgoCD synced clean, the migration hook Job completed, and its logs shipped via the log-collector.

Bumps chart to 0.9.1; CHANGELOG updated.